### PR TITLE
Fix Dockerized React dashboard asset copy

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.DS_Store
+.git
+.gitignore
+Dockerfile

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,8 +5,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 
-COPY public ./public
-COPY src ./src
+COPY . .
 
 ENV HOST=0.0.0.0
 


### PR DESCRIPTION
## Summary
- add a frontend .dockerignore to keep local modules out of the image build context
- update the frontend Dockerfile to copy the complete project so public/index.html is always present

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5a07019448333a9d8776902a0f8d7