### PR TITLE
Fix frontend Dockerfile to include public assets

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,10 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 
-COPY . .
+COPY public ./public
+COPY src ./src
+
+RUN test -f public/index.html
 
 ENV HOST=0.0.0.0
 


### PR DESCRIPTION
## Summary
- ensure the frontend Docker image copies the public and src directories explicitly
- add a build-time check to verify public/index.html exists

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68e5a4195f7083338c2727eb47d2f8c0