### PR TITLE
Fix frontend lockfile mismatch and ignore build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 */node_modules/
 backend/build/
+frontend/build/
 .DS_Store

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16489,9 +16489,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -16499,7 +16499,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {


### PR DESCRIPTION
## Summary
- align the frontend lockfile with the dependency tree so clean installs succeed again
- add the React production build directory to .gitignore to keep generated assets out of version control

## Testing
- cmake --build backend/build
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5b20364388333b8bf566664d2d1dc