### PR TITLE
Fix dashboard text contrast on gradient background

### DIFF
--- a/frontend/src/components/ConnectionsChart.js
+++ b/frontend/src/components/ConnectionsChart.js
@@ -23,10 +23,10 @@ function ConnectionsChart({ data }) {
             </linearGradient>
           </defs>
           <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" />
-          <XAxis dataKey="time" tick={{ fill: 'var(--text-muted)', fontSize: 12 }} />
+          <XAxis dataKey="time" tick={{ fill: 'var(--text-surface-muted)', fontSize: 12 }} />
           <YAxis
             width={60}
-            tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
+            tick={{ fill: 'var(--text-surface-muted)', fontSize: 12 }}
             allowDecimals={false}
             domain={['auto', 'auto']}
           />
@@ -36,10 +36,11 @@ function ConnectionsChart({ data }) {
               background: 'var(--surface-elevated)',
               borderRadius: 12,
               border: '1px solid var(--border-soft)',
-              color: 'var(--text-primary)',
+              color: 'var(--text-surface)',
               fontSize: 13
             }}
-            labelStyle={{ color: 'var(--text-muted)' }}
+            labelStyle={{ color: 'var(--text-surface-muted)' }}
+            itemStyle={{ color: 'var(--text-surface)' }}
             formatter={tooltipFormatter}
           />
           <Area

--- a/frontend/src/components/MetricChart.js
+++ b/frontend/src/components/MetricChart.js
@@ -16,10 +16,10 @@ function MetricChart({ data }) {
       <ResponsiveContainer width="100%" height={280}>
         <LineChart data={data} margin={{ top: 12, right: 24, left: 0, bottom: 0 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" />
-          <XAxis dataKey="time" tick={{ fill: 'var(--text-muted)', fontSize: 12 }} />
+          <XAxis dataKey="time" tick={{ fill: 'var(--text-surface-muted)', fontSize: 12 }} />
           <YAxis
             width={60}
-            tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
+            tick={{ fill: 'var(--text-surface-muted)', fontSize: 12 }}
             domain={[0, 100]}
             unit="%"
           />
@@ -29,12 +29,19 @@ function MetricChart({ data }) {
               background: 'var(--surface-elevated)',
               borderRadius: 12,
               border: '1px solid var(--border-soft)',
-              color: 'var(--text-primary)',
+              color: 'var(--text-surface)',
               fontSize: 13
             }}
-            labelStyle={{ color: 'var(--text-muted)' }}
+            labelStyle={{ color: 'var(--text-surface-muted)' }}
+            itemStyle={{ color: 'var(--text-surface)' }}
           />
-          <Legend verticalAlign="top" height={32} iconType="circle" iconSize={10} />
+          <Legend
+            verticalAlign="top"
+            height={32}
+            iconType="circle"
+            iconSize={10}
+            wrapperStyle={{ color: 'var(--text-surface-muted)' }}
+          />
           <Line
             type="monotone"
             dataKey="cpu"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,8 +4,10 @@
   --bg-gradient: linear-gradient(145deg, #0f172a 0%, #1e293b 40%, #0b1120 100%);
   --surface: rgba(255, 255, 255, 0.92);
   --surface-elevated: rgba(255, 255, 255, 0.98);
-  --text-primary: #0f172a;
-  --text-muted: #475569;
+  --text-primary: #f8fafc;
+  --text-muted: rgba(226, 232, 240, 0.78);
+  --text-surface: #0f172a;
+  --text-surface-muted: #475569;
   --border-soft: rgba(148, 163, 184, 0.25);
   --shadow-soft: 0 24px 60px -40px rgba(15, 23, 42, 0.65);
   --shadow-card: 0 20px 50px -35px rgba(15, 23, 42, 0.55);
@@ -80,6 +82,7 @@ a {
   font-size: clamp(2.4rem, 2.6vw + 1rem, 3.2rem);
   letter-spacing: -0.04em;
   line-height: 1.1;
+  color: var(--text-primary);
 }
 
 .app-eyebrow {
@@ -93,6 +96,7 @@ a {
 .app-subtitle {
   margin-top: 12px;
   max-width: 520px;
+  color: var(--text-muted);
 }
 
 .app-header__status {
@@ -209,6 +213,7 @@ a {
   flex-direction: column;
   gap: 12px;
   min-height: 172px;
+  color: var(--text-surface);
 }
 
 .metric-card::after {
@@ -225,7 +230,7 @@ a {
   font-size: 0.95rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--text-surface-muted);
 }
 
 .metric-card__value-row {
@@ -238,19 +243,19 @@ a {
   font-size: clamp(2.4rem, 3vw + 1rem, 3.2rem);
   font-weight: 700;
   letter-spacing: -0.05em;
-  color: var(--text-primary);
+  color: var(--text-surface);
 }
 
 .metric-card__unit {
   font-size: 1.1rem;
   font-weight: 500;
-  color: var(--text-muted);
+  color: var(--text-surface-muted);
   margin-bottom: 8px;
 }
 
 .metric-card__helper {
   font-size: 0.95rem;
-  color: var(--text-muted);
+  color: var(--text-surface-muted);
 }
 
 .metric-card__trend {
@@ -274,7 +279,7 @@ a {
 }
 
 .metric-card__trend--steady {
-  color: var(--text-muted);
+  color: var(--text-surface-muted);
 }
 
 .metric-card--healthy {
@@ -313,6 +318,11 @@ a {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  color: var(--text-surface);
+}
+
+.panel p {
+  color: var(--text-surface-muted);
 }
 
 .panel--primary {
@@ -337,11 +347,13 @@ a {
 
 .panel__header h2 {
   font-size: 1.2rem;
+  color: var(--text-surface);
 }
 
 .panel__header p {
   margin-top: 4px;
   font-size: 0.95rem;
+  color: var(--text-surface-muted);
 }
 
 .panel__tag {
@@ -427,28 +439,28 @@ a {
 
 .timeline__status {
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--text-surface);
 }
 
 .timeline__time {
   font-size: 0.85rem;
-  color: var(--text-muted);
+  color: var(--text-surface-muted);
 }
 
 .timeline__description {
   margin-top: 8px;
   font-weight: 500;
-  color: var(--text-primary);
+  color: var(--text-surface);
 }
 
 .timeline__metrics {
   margin-top: 4px;
   font-size: 0.85rem;
-  color: var(--text-muted);
+  color: var(--text-surface-muted);
 }
 
 .timeline__empty {
-  color: var(--text-muted);
+  color: var(--text-surface-muted);
   font-style: italic;
 }
 
@@ -463,7 +475,7 @@ a {
   text-transform: uppercase;
   font-size: 0.72rem;
   letter-spacing: 0.08em;
-  color: var(--text-muted);
+  color: var(--text-surface-muted);
 }
 
 .insights-table th,
@@ -471,6 +483,7 @@ a {
   padding: 12px 16px;
   text-align: left;
   border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  color: var(--text-surface);
 }
 
 .insights-table tbody tr:last-child td {
@@ -503,14 +516,14 @@ a {
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: var(--text-muted);
+  color: var(--text-surface-muted);
 }
 
 .insights-meta__value {
   margin: 6px 0 0;
   font-size: 1.1rem;
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--text-surface);
 }
 
 .app-footer {


### PR DESCRIPTION
## Summary
- adjust global typography variables so background sections use light text while cards use dedicated surface colors
- update card, panel, and table styles to use new surface text tokens for consistent readability
- update chart axes, legends, and tooltips to use surface text tokens so overlays remain legible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5b46513e083338c716421e73ce72d