### PR TITLE
Add configurable retention and expand dashboard analytics

### DIFF
--- a/backend/src/rest_server.cpp
+++ b/backend/src/rest_server.cpp
@@ -58,6 +58,32 @@ void RestServer::handle_get(web::http::http_request request)
     response[utility::conversions::to_string_t("cpuCores")] = web::json::value::number(m.cpuCount);
     response[utility::conversions::to_string_t("timestamp")] = web::json::value::string(utility::conversions::to_string_t(MetricsCollector::to_iso8601(m.timestamp)));
 
+    web::json::value applications = web::json::value::array(m.topApplications.size());
+    for (std::size_t i = 0; i < m.topApplications.size(); ++i)
+    {
+        const auto &app = m.topApplications[i];
+        web::json::value item;
+        item[utility::conversions::to_string_t("pid")] = web::json::value::number(app.pid);
+        item[utility::conversions::to_string_t("name")] = web::json::value::string(utility::conversions::to_string_t(app.name));
+        item[utility::conversions::to_string_t("cpu")] = web::json::value::number(app.cpuPercent);
+        item[utility::conversions::to_string_t("memoryMb")] = web::json::value::number(app.memoryMb);
+        applications[i] = std::move(item);
+    }
+    response[utility::conversions::to_string_t("applications")] = std::move(applications);
+
+    web::json::value domains = web::json::value::array(m.domainUsage.size());
+    for (std::size_t i = 0; i < m.domainUsage.size(); ++i)
+    {
+        const auto &domain = m.domainUsage[i];
+        web::json::value item;
+        item[utility::conversions::to_string_t("domain")] = web::json::value::string(utility::conversions::to_string_t(domain.domain));
+        item[utility::conversions::to_string_t("receiveRate")] = web::json::value::number(domain.receiveRate);
+        item[utility::conversions::to_string_t("transmitRate")] = web::json::value::number(domain.transmitRate);
+        item[utility::conversions::to_string_t("connections")] = web::json::value::number(domain.connections);
+        domains[i] = std::move(item);
+    }
+    response[utility::conversions::to_string_t("domains")] = std::move(domains);
+
     web::http::http_response httpResponse(web::http::status_codes::OK);
     httpResponse.headers().add(web::http::header_names::cache_control, utility::conversions::to_string_t("no-store"));
     httpResponse.headers().add(web::http::header_names::content_type, utility::conversions::to_string_t("application/json"));

--- a/backend/src/system_metrics.cpp
+++ b/backend/src/system_metrics.cpp
@@ -3,6 +3,8 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <cctype>
+#include <cstdlib>
 #include <exception>
 #include <fstream>
 #include <iomanip>
@@ -10,8 +12,13 @@
 #include <string>
 #include <thread>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 #include <ctime>
+#include <dirent.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
 #include <sys/statvfs.h>
 #include <unistd.h>
 
@@ -22,13 +29,107 @@ constexpr const char *PROC_MEMINFO_PATH = "/proc/meminfo";
 constexpr const char *PROC_TCP4_PATH = "/proc/net/tcp";
 constexpr const char *PROC_TCP6_PATH = "/proc/net/tcp6";
 constexpr const char *PROC_NET_DEV_PATH = "/proc/net/dev";
+bool is_active_tcp_state(int state)
+{
+    switch (state)
+    {
+    case 0x01: // ESTABLISHED
+    case 0x02: // SYN_SENT
+    case 0x03: // SYN_RECV
+    case 0x04: // FIN_WAIT1
+    case 0x05: // FIN_WAIT2
+    case 0x06: // TIME_WAIT
+    case 0x08: // CLOSE_WAIT
+    case 0x09: // LAST_ACK
+    case 0x0B: // CLOSING
+    case 0x0C: // NEW_SYN_RECV
+        return true;
+    default:
+        return false;
+    }
 }
+
+std::string decode_ipv4_address(const std::string &hex)
+{
+    if (hex.size() != 8)
+    {
+        return "unknown";
+    }
+
+    try
+    {
+        unsigned long value = std::stoul(hex, nullptr, 16);
+        in_addr addr{};
+        addr.s_addr = htonl(static_cast<uint32_t>(value));
+        char buffer[INET_ADDRSTRLEN];
+        if (inet_ntop(AF_INET, &addr, buffer, sizeof(buffer)) == nullptr)
+        {
+            return "unknown";
+        }
+        return buffer;
+    }
+    catch (const std::exception &)
+    {
+        return "unknown";
+    }
+}
+
+std::string decode_ipv6_address(const std::string &hex)
+{
+    if (hex.size() != 32)
+    {
+        return "unknown";
+    }
+
+    std::array<unsigned char, 16> raw{};
+    for (std::size_t i = 0; i < raw.size(); ++i)
+    {
+        const std::size_t index = i * 2;
+        const std::string byte_str = hex.substr(index, 2);
+        try
+        {
+            raw[i] = static_cast<unsigned char>(std::stoul(byte_str, nullptr, 16));
+        }
+        catch (const std::exception &)
+        {
+            return "unknown";
+        }
+    }
+
+    std::array<unsigned char, 16> reordered{};
+    for (std::size_t chunk = 0; chunk < 4; ++chunk)
+    {
+        reordered[chunk * 4 + 0] = raw[chunk * 4 + 3];
+        reordered[chunk * 4 + 1] = raw[chunk * 4 + 2];
+        reordered[chunk * 4 + 2] = raw[chunk * 4 + 1];
+        reordered[chunk * 4 + 3] = raw[chunk * 4 + 0];
+    }
+
+    char buffer[INET6_ADDRSTRLEN];
+    if (inet_ntop(AF_INET6, reordered.data(), buffer, sizeof(buffer)) == nullptr)
+    {
+        return "unknown";
+    }
+    return buffer;
+}
+
+std::string format_domain_label(const std::string &address)
+{
+    if (address == "unknown")
+    {
+        return "unresolved";
+    }
+    return address;
+}
+
+} // namespace
 
 MetricsCollector::MetricsCollector()
     : mutex_(),
       cpu_initialized_(false),
       previous_total_(0),
       previous_idle_(0),
+      last_cpu_total_diff_(0),
       cpu_count_cached_(false),
       cached_cpu_count_(1),
       network_initialized_(false),
@@ -56,7 +157,6 @@ SystemMetrics MetricsCollector::collect()
     metrics.timestamp = std::chrono::system_clock::now();
     metrics.cpuUsage = read_cpu_usage();
     metrics.memoryUsage = read_memory_usage();
-    metrics.activeConnections = read_active_connections();
     metrics.diskUsage = read_disk_usage();
     auto [rx_rate, tx_rate] = read_network_throughput();
     metrics.networkReceiveRate = rx_rate;
@@ -66,6 +166,10 @@ SystemMetrics MetricsCollector::collect()
     metrics.loadAverage5 = load_avgs[1];
     metrics.loadAverage15 = load_avgs[2];
     metrics.cpuCount = detect_cpu_count();
+    auto connectionSummary = read_connection_summary();
+    metrics.activeConnections = connectionSummary.totalConnections;
+    metrics.domainUsage = build_domain_usage(connectionSummary, metrics.networkReceiveRate, metrics.networkTransmitRate);
+    metrics.topApplications = read_application_usage();
 
     cached_metrics_ = metrics;
     last_collection_time_ = now;
@@ -103,6 +207,7 @@ double MetricsCollector::read_cpu_usage()
         cpu_initialized_ = true;
         previous_total_ = total;
         previous_idle_ = idle_all;
+        last_cpu_total_diff_ = 0;
         return 0.0;
     }
 
@@ -111,9 +216,11 @@ double MetricsCollector::read_cpu_usage()
 
     previous_total_ = total;
     previous_idle_ = idle_all;
+    last_cpu_total_diff_ = total_diff;
 
     if (total_diff == 0)
     {
+        last_cpu_total_diff_ = 0;
         return 0.0;
     }
 
@@ -160,77 +267,6 @@ double MetricsCollector::read_memory_usage()
     const double used = static_cast<double>(mem_total - mem_available);
     const double usage = (used / static_cast<double>(mem_total)) * 100.0;
     return std::clamp(usage, 0.0, 100.0);
-}
-
-int MetricsCollector::read_active_connections()
-{
-    int connections_v4 = count_connections_from_proc(PROC_TCP4_PATH);
-    int connections_v6 = count_connections_from_proc(PROC_TCP6_PATH);
-    return connections_v4 + connections_v6;
-}
-
-int MetricsCollector::count_connections_from_proc(const std::string &path)
-{
-    std::ifstream tcp_file(path);
-    if (!tcp_file.is_open())
-    {
-        return 0;
-    }
-
-    std::string line;
-    int count = 0;
-
-    // Skip header line
-    std::getline(tcp_file, line);
-
-    while (std::getline(tcp_file, line))
-    {
-        if (line.empty())
-        {
-            continue;
-        }
-
-        std::istringstream ss(line);
-        std::string sl;
-        std::string local_address;
-        std::string rem_address;
-        std::string state_hex;
-
-        if (!(ss >> sl >> local_address >> rem_address >> state_hex))
-        {
-            continue;
-        }
-
-        int state = 0;
-        try
-        {
-            state = std::stoi(state_hex, nullptr, 16);
-        }
-        catch (const std::exception &)
-        {
-            continue;
-        }
-
-        switch (state)
-        {
-        case 0x01: // ESTABLISHED
-        case 0x02: // SYN_SENT
-        case 0x03: // SYN_RECV
-        case 0x04: // FIN_WAIT1
-        case 0x05: // FIN_WAIT2
-        case 0x06: // TIME_WAIT
-        case 0x08: // CLOSE_WAIT
-        case 0x09: // LAST_ACK
-        case 0x0B: // CLOSING
-        case 0x0C: // NEW_SYN_RECV
-            ++count;
-            break;
-        default:
-            break;
-        }
-    }
-
-    return count;
 }
 
 double MetricsCollector::read_disk_usage()
@@ -330,6 +366,235 @@ std::tuple<double, double> MetricsCollector::read_network_throughput()
     previous_tx_bytes_ = tx_total;
 
     return {std::max(0.0, rx_rate), std::max(0.0, tx_rate)};
+}
+
+std::vector<ApplicationUsage> MetricsCollector::read_application_usage()
+{
+    std::vector<ApplicationUsage> result;
+    const unsigned long long total_diff = last_cpu_total_diff_;
+
+    DIR *proc_dir = opendir("/proc");
+    if (proc_dir == nullptr)
+    {
+        process_cpu_times_.clear();
+        return result;
+    }
+
+    std::unordered_map<int, unsigned long long> next_cpu_times;
+    struct dirent *entry = nullptr;
+
+    while ((entry = readdir(proc_dir)) != nullptr)
+    {
+        if (entry->d_name == nullptr || !std::isdigit(static_cast<unsigned char>(entry->d_name[0])))
+        {
+            continue;
+        }
+
+        const int pid = std::atoi(entry->d_name);
+        const std::string base_path = std::string("/proc/") + entry->d_name;
+
+        std::ifstream stat_file(base_path + "/stat");
+        if (!stat_file.is_open())
+        {
+            continue;
+        }
+
+        std::string stat_line;
+        std::getline(stat_file, stat_line);
+        stat_file.close();
+
+        const std::size_t open = stat_line.find('(');
+        const std::size_t close = stat_line.rfind(')');
+        if (open == std::string::npos || close == std::string::npos || close <= open)
+        {
+            continue;
+        }
+
+        std::string name = stat_line.substr(open + 1, close - open - 1);
+        std::string remainder = close + 1 < stat_line.size() ? stat_line.substr(close + 2) : std::string();
+        std::istringstream fields(remainder);
+
+        std::string token;
+        for (int i = 0; i < 11; ++i)
+        {
+            if (!(fields >> token))
+            {
+                token.clear();
+                break;
+            }
+        }
+
+        unsigned long long utime = 0;
+        unsigned long long stime = 0;
+        if (!(fields >> utime >> stime))
+        {
+            continue;
+        }
+
+        const unsigned long long cpu_time = utime + stime;
+        next_cpu_times[pid] = cpu_time;
+
+        double cpuPercent = 0.0;
+        auto prev_iter = process_cpu_times_.find(pid);
+        if (prev_iter != process_cpu_times_.end() && cpu_time >= prev_iter->second && total_diff > 0)
+        {
+            const unsigned long long delta = cpu_time - prev_iter->second;
+            cpuPercent = static_cast<double>(delta) / static_cast<double>(total_diff) * 100.0;
+        }
+
+        std::ifstream status_file(base_path + "/status");
+        double memoryMb = 0.0;
+        if (status_file.is_open())
+        {
+            std::string line;
+            while (std::getline(status_file, line))
+            {
+                if (line.rfind("VmRSS:", 0) == 0)
+                {
+                    std::istringstream rss_stream(line.substr(6));
+                    unsigned long long rss_kb = 0;
+                    rss_stream >> rss_kb;
+                    memoryMb = static_cast<double>(rss_kb) / 1024.0;
+                    break;
+                }
+            }
+        }
+
+        ApplicationUsage usage{pid, name, cpuPercent, memoryMb};
+        result.push_back(std::move(usage));
+    }
+
+    closedir(proc_dir);
+    process_cpu_times_ = std::move(next_cpu_times);
+
+    std::sort(result.begin(), result.end(), [](const ApplicationUsage &lhs, const ApplicationUsage &rhs) {
+        if (std::abs(lhs.cpuPercent - rhs.cpuPercent) > 0.0001)
+        {
+            return lhs.cpuPercent > rhs.cpuPercent;
+        }
+        if (std::abs(lhs.memoryMb - rhs.memoryMb) > 0.0001)
+        {
+            return lhs.memoryMb > rhs.memoryMb;
+        }
+        return lhs.pid < rhs.pid;
+    });
+
+    constexpr std::size_t maxApplications = 8;
+    if (result.size() > maxApplications)
+    {
+        result.resize(maxApplications);
+    }
+
+    return result;
+}
+
+MetricsCollector::ConnectionSummary MetricsCollector::read_connection_summary()
+{
+    ConnectionSummary summary{};
+    summary.totalConnections = 0;
+
+    auto parse_tcp_file = [&summary](const std::string &path, bool ipv6) {
+        std::ifstream tcp_file(path);
+        if (!tcp_file.is_open())
+        {
+            return;
+        }
+
+        std::string line;
+        std::getline(tcp_file, line); // skip header
+
+        while (std::getline(tcp_file, line))
+        {
+            if (line.empty())
+            {
+                continue;
+            }
+
+            std::istringstream ss(line);
+            std::string sl;
+            std::string local_address;
+            std::string rem_address;
+            std::string state_hex;
+
+            if (!(ss >> sl >> local_address >> rem_address >> state_hex))
+            {
+                continue;
+            }
+
+            int state = 0;
+            try
+            {
+                state = std::stoi(state_hex, nullptr, 16);
+            }
+            catch (const std::exception &)
+            {
+                continue;
+            }
+
+            if (!is_active_tcp_state(state))
+            {
+                continue;
+            }
+
+            const auto colon_pos = rem_address.find(':');
+            if (colon_pos == std::string::npos)
+            {
+                continue;
+            }
+
+            const std::string remote_hex = rem_address.substr(0, colon_pos);
+            std::string domain = ipv6 ? decode_ipv6_address(remote_hex) : decode_ipv4_address(remote_hex);
+            domain = format_domain_label(domain);
+
+            ++summary.domainCounts[domain];
+            ++summary.totalConnections;
+        }
+    };
+
+    parse_tcp_file(PROC_TCP4_PATH, false);
+    parse_tcp_file(PROC_TCP6_PATH, true);
+
+    return summary;
+}
+
+std::vector<DomainUsage> MetricsCollector::build_domain_usage(const ConnectionSummary &summary, double totalRx, double totalTx) const
+{
+    std::vector<DomainUsage> result;
+    if (summary.totalConnections <= 0 || summary.domainCounts.empty())
+    {
+        return result;
+    }
+
+    for (const auto &entry : summary.domainCounts)
+    {
+        DomainUsage usage;
+        usage.domain = entry.first;
+        usage.connections = entry.second;
+        const double ratio = static_cast<double>(entry.second) / static_cast<double>(summary.totalConnections);
+        usage.receiveRate = totalRx * ratio;
+        usage.transmitRate = totalTx * ratio;
+        result.push_back(std::move(usage));
+    }
+
+    std::sort(result.begin(), result.end(), [](const DomainUsage &lhs, const DomainUsage &rhs) {
+        if (lhs.connections != rhs.connections)
+        {
+            return lhs.connections > rhs.connections;
+        }
+        if (std::abs(lhs.receiveRate - rhs.receiveRate) > 0.0001)
+        {
+            return lhs.receiveRate > rhs.receiveRate;
+        }
+        return lhs.domain < rhs.domain;
+    });
+
+    constexpr std::size_t maxDomains = 10;
+    if (result.size() > maxDomains)
+    {
+        result.resize(maxDomains);
+    }
+
+    return result;
 }
 
 std::array<double, 3> MetricsCollector::read_load_averages() const

--- a/backend/src/websocket_server.cpp
+++ b/backend/src/websocket_server.cpp
@@ -203,6 +203,26 @@ void WebSocketServer::run() {
                         j["netTx"] = m.networkTransmitRate;
                         j["cpuCores"] = m.cpuCount;
                         j["timestamp"] = MetricsCollector::to_iso8601(m.timestamp);
+                        j["applications"] = nlohmann::json::array();
+                        for (const auto &app : m.topApplications)
+                        {
+                            j["applications"].push_back({
+                                {"pid", app.pid},
+                                {"name", app.name},
+                                {"cpu", app.cpuPercent},
+                                {"memoryMb", app.memoryMb}
+                            });
+                        }
+                        j["domains"] = nlohmann::json::array();
+                        for (const auto &domain : m.domainUsage)
+                        {
+                            j["domains"].push_back({
+                                {"domain", domain.domain},
+                                {"receiveRate", domain.receiveRate},
+                                {"transmitRate", domain.transmitRate},
+                                {"connections", domain.connections}
+                            });
+                        }
 
                         ws.write(net::buffer(j.dump()));
                         std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/frontend/src/components/AppHeader.js
+++ b/frontend/src/components/AppHeader.js
@@ -2,7 +2,18 @@ import React from 'react';
 
 import { connectionLabel, healthLabel } from '../constants/status';
 
-function AppHeader({ connectionState, health }) {
+function AppHeader({ connectionState, health, onOpenSettings, retentionDays }) {
+  const handleOpenSettings = () => {
+    if (typeof onOpenSettings === 'function') {
+      onOpenSettings();
+    }
+  };
+
+  const retentionNumeric = Number(retentionDays);
+  const retentionLabel = Number.isFinite(retentionNumeric) && retentionNumeric > 0
+    ? `${retentionNumeric} day${retentionNumeric === 1 ? '' : 's'}`
+    : 'configurable retention';
+
   return (
     <header className="app-header">
       <div className="app-header__titles">
@@ -10,9 +21,14 @@ function AppHeader({ connectionState, health }) {
         <h1>Realtime Infrastructure Overview</h1>
         <p className="app-subtitle">
           Unified insights for system health, utilisation and client connectivity.
+          {' '}
+          <span className="app-subtitle__meta">Currently retaining {retentionLabel} of streaming telemetry.</span>
         </p>
       </div>
       <div className="app-header__status">
+        <button type="button" className="settings-button" onClick={handleOpenSettings}>
+          Dashboard settings
+        </button>
         <span className={`status-pill status-pill--${connectionState}`}>
           <span className="status-indicator" aria-hidden="true" />
           {connectionLabel[connectionState]}

--- a/frontend/src/components/ApplicationUsagePanel.js
+++ b/frontend/src/components/ApplicationUsagePanel.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { formatMegabytes, formatPercentLabel } from '../utils/formatters';
+
+function ApplicationUsagePanel({ applications }) {
+  const hasData = Array.isArray(applications) && applications.length > 0;
+
+  return (
+    <article className="panel">
+      <div className="panel__header">
+        <div>
+          <h2>Application utilisation</h2>
+          <p>Top processes ranked by CPU saturation with resident memory usage.</p>
+        </div>
+      </div>
+      {hasData ? (
+        <table className="detail-table" aria-label="Top application resource usage">
+          <thead>
+            <tr>
+              <th scope="col">Application</th>
+              <th scope="col">CPU</th>
+              <th scope="col">Memory</th>
+              <th scope="col">PID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {applications.map((app) => (
+              <tr key={`${app.pid}-${app.name}`}>
+                <th scope="row">
+                  <div className="entity-name">{app.name || `Process ${app.pid}`}</div>
+                  <div className="entity-meta">PID {app.pid}</div>
+                </th>
+                <td>{formatPercentLabel(app.cpu)}</td>
+                <td>{formatMegabytes(app.memoryMb)}</td>
+                <td>{app.pid}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <div className="panel__empty" role="status">
+          <p>No processes sampled yet. Waiting for activity.</p>
+        </div>
+      )}
+    </article>
+  );
+}
+
+export default ApplicationUsagePanel;
+

--- a/frontend/src/components/DomainTrafficPanel.js
+++ b/frontend/src/components/DomainTrafficPanel.js
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { formatConnections, formatThroughput } from '../utils/formatters';
+
+function DomainTrafficPanel({ domains, totalConnections, throughput }) {
+  const hasData = Array.isArray(domains) && domains.length > 0;
+  const summaryLabel = totalConnections ? `${formatConnections(totalConnections)} active connections` : 'No active connections';
+
+  return (
+    <article className="panel">
+      <div className="panel__header">
+        <div>
+          <h2>Network usage by domain</h2>
+          <p>Observed TCP peers with proportional inbound and outbound throughput.</p>
+        </div>
+        <div className="panel__helper" aria-live="polite">{summaryLabel}</div>
+      </div>
+      {hasData ? (
+        <table className="detail-table" aria-label="Network usage per domain">
+          <thead>
+            <tr>
+              <th scope="col">Remote domain</th>
+              <th scope="col">Connections</th>
+              <th scope="col">Inbound</th>
+              <th scope="col">Outbound</th>
+            </tr>
+          </thead>
+          <tbody>
+            {domains.map((domain) => (
+              <tr key={`${domain.domain}-${domain.connections}`}>
+                <th scope="row">
+                  <div className="entity-name">{domain.domain}</div>
+                  <div className="entity-meta">{formatConnections(domain.connections)} connections</div>
+                </th>
+                <td>{formatConnections(domain.connections)}</td>
+                <td>{formatThroughput(domain.receiveRate)}</td>
+                <td>{formatThroughput(domain.transmitRate)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <div className="panel__empty" role="status">
+          <p>No network peers detected for the current sampling window.</p>
+        </div>
+      )}
+      <footer className="panel__footer">
+        <p>
+          Aggregate throughput: ↓{formatThroughput(throughput?.inbound)} • ↑{formatThroughput(throughput?.outbound)}
+        </p>
+      </footer>
+    </article>
+  );
+}
+
+export default DomainTrafficPanel;
+

--- a/frontend/src/components/SettingsPanel.js
+++ b/frontend/src/components/SettingsPanel.js
@@ -1,0 +1,95 @@
+import React, { useEffect, useMemo } from 'react';
+
+function SettingsPanel({ open, onClose, retentionDays, onRetentionChange }) {
+  const safeRetention = useMemo(() => {
+    const numeric = Number(retentionDays);
+    if (!Number.isFinite(numeric) || numeric <= 0) {
+      return 1;
+    }
+    return Math.max(1, Math.min(30, Math.round(numeric)));
+  }, [retentionDays]);
+
+  const handleSliderChange = (event) => {
+    onRetentionChange(Number(event.target.value));
+  };
+
+  const handleNumberChange = (event) => {
+    const value = Number(event.target.value);
+    if (Number.isFinite(value)) {
+      onRetentionChange(value);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  return (
+    <div className={`settings-panel ${open ? 'settings-panel--open' : ''}`} aria-hidden={!open}>
+      <div className="settings-panel__backdrop" role="presentation" onClick={onClose} />
+      <aside className="settings-panel__surface" role="dialog" aria-modal="true" aria-labelledby="settings-panel-title">
+        <header className="settings-panel__header">
+          <div>
+            <p className="settings-panel__eyebrow">Configuration</p>
+            <h2 id="settings-panel-title">Dashboard settings</h2>
+            <p className="settings-panel__summary">
+              Control retention of historical samples for time series visualisations.
+            </p>
+          </div>
+          <button type="button" className="settings-panel__close" onClick={onClose}>
+            Close
+          </button>
+        </header>
+        <div className="settings-panel__content">
+          <label htmlFor="retention-slider" className="settings-panel__label">
+            Data retention window
+          </label>
+          <p className="settings-panel__description">
+            Choose how many days of metrics to retain in the live session. Increasing this enables long-term trend
+            analysis at the cost of higher memory usage in the browser.
+          </p>
+          <div className="settings-panel__field">
+            <input
+              id="retention-slider"
+              type="range"
+              min="1"
+              max="30"
+              value={safeRetention}
+              onChange={handleSliderChange}
+            />
+            <input
+              type="number"
+              min="1"
+              max="30"
+              value={safeRetention}
+              onChange={handleNumberChange}
+              aria-label="Retention window in days"
+            />
+            <span className="settings-panel__value">{safeRetention} days</span>
+          </div>
+          <ul className="settings-panel__tips">
+            <li>7 days provides a balance of fidelity and responsiveness.</li>
+            <li>Use a smaller window for highly transient workloads.</li>
+            <li>Use a larger window to support weekly operational reviews.</li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+export default SettingsPanel;
+

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,9 +1,19 @@
 const rawMaxPoints = Number(process.env.REACT_APP_MAX_POINTS || 180);
+const rawSampleInterval = Number(process.env.REACT_APP_SAMPLE_INTERVAL_SECONDS || 1);
+const rawRetentionDays = Number(process.env.REACT_APP_DEFAULT_RETENTION_DAYS || 7);
+
+const sampleIntervalSeconds = Number.isFinite(rawSampleInterval) && rawSampleInterval > 0 ? rawSampleInterval : 1;
+const defaultRetentionDays = Number.isFinite(rawRetentionDays) && rawRetentionDays > 0 ? rawRetentionDays : 7;
+const defaultRetentionSeconds = defaultRetentionDays * 24 * 60 * 60;
+const fallbackMaxPoints = Number.isFinite(rawMaxPoints) && rawMaxPoints > 0 ? rawMaxPoints : Math.ceil(defaultRetentionSeconds / sampleIntervalSeconds);
 
 export const appConfig = {
   websocketUrl: process.env.REACT_APP_WS_URL || 'ws://localhost:9002',
   apiToken: process.env.REACT_APP_API_TOKEN || '',
-  maxDataPoints: Number.isFinite(rawMaxPoints) && rawMaxPoints > 0 ? rawMaxPoints : 180
+  sampleIntervalSeconds,
+  defaultRetentionDays,
+  defaultRetentionSeconds,
+  maxDataPoints: Math.max(fallbackMaxPoints, Math.ceil(defaultRetentionSeconds / sampleIntervalSeconds))
 };
 
 export const buildWebSocketUrl = () => {

--- a/frontend/src/hooks/useSettings.js
+++ b/frontend/src/hooks/useSettings.js
@@ -1,0 +1,86 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+import { appConfig } from '../config';
+
+const SettingsContext = createContext(undefined);
+const STORAGE_KEY = 'monitoring.settings.v1';
+
+const clampRetentionDays = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return appConfig.defaultRetentionDays;
+  }
+  return Math.max(1, Math.min(30, Math.round(numeric)));
+};
+
+const defaultSettings = {
+  retentionDays: appConfig.defaultRetentionDays
+};
+
+const readStoredSettings = () => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return defaultSettings;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return defaultSettings;
+    }
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return defaultSettings;
+    }
+    return {
+      retentionDays: clampRetentionDays(parsed.retentionDays)
+    };
+  } catch (error) {
+    return defaultSettings;
+  }
+};
+
+export const SettingsProvider = ({ children }) => {
+  const [settings, setSettings] = useState(() => readStoredSettings());
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  }, [settings]);
+
+  const updateSetting = useCallback((key, value) => {
+    setSettings((previous) => {
+      const nextValue = key === 'retentionDays' ? clampRetentionDays(value) : value;
+      if (previous[key] === nextValue) {
+        return previous;
+      }
+      return { ...previous, [key]: nextValue };
+    });
+  }, []);
+
+  const retentionSeconds = useMemo(() => {
+    return Math.max(1, settings.retentionDays) * 24 * 60 * 60;
+  }, [settings.retentionDays]);
+
+  const contextValue = useMemo(
+    () => ({
+      settings,
+      retentionSeconds,
+      retentionDays: settings.retentionDays,
+      updateSetting
+    }),
+    [settings, retentionSeconds, updateSetting]
+  );
+
+  return <SettingsContext.Provider value={contextValue}>{children}</SettingsContext.Provider>;
+};
+
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return context;
+};
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -526,6 +526,209 @@ a {
   color: var(--text-surface);
 }
 
+.app-subtitle__meta {
+  display: block;
+  margin-top: 8px;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.settings-button {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  background: rgba(148, 163, 184, 0.25);
+  color: var(--text-primary);
+  transition: background 0.2s ease, transform 0.2s ease;
+  backdrop-filter: blur(8px);
+}
+
+.settings-button:hover,
+.settings-button:focus {
+  background: rgba(148, 163, 184, 0.4);
+  transform: translateY(-1px);
+}
+
+.panel__helper {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-surface-muted);
+}
+
+.detail-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.detail-table thead {
+  background: rgba(148, 163, 184, 0.12);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--text-surface-muted);
+}
+
+.detail-table th,
+.detail-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  text-align: left;
+  color: var(--text-surface);
+}
+
+.detail-table tbody tr:last-child th,
+.detail-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.entity-name {
+  font-weight: 600;
+  color: var(--text-surface);
+}
+
+.entity-meta {
+  margin-top: 4px;
+  font-size: 0.8rem;
+  color: var(--text-surface-muted);
+}
+
+.panel__empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 16px;
+  color: var(--text-surface-muted);
+  font-style: italic;
+}
+
+.panel__footer {
+  padding-top: 12px;
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  font-size: 0.85rem;
+  color: var(--text-surface-muted);
+}
+
+.settings-panel {
+  position: fixed;
+  inset: 0;
+  display: none;
+  z-index: 40;
+}
+
+.settings-panel--open {
+  display: block;
+}
+
+.settings-panel__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(4px);
+}
+
+.settings-panel__surface {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: min(420px, 100%);
+  height: 100%;
+  background: rgba(15, 23, 42, 0.98);
+  color: var(--text-primary);
+  display: flex;
+  flex-direction: column;
+  box-shadow: -24px 0 60px -40px rgba(15, 23, 42, 0.75);
+  padding: 32px;
+  gap: 24px;
+}
+
+.settings-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.settings-panel__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.75);
+  margin: 0 0 8px;
+}
+
+.settings-panel__summary {
+  margin-top: 8px;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.settings-panel__close {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-primary);
+  padding: 6px 14px;
+  cursor: pointer;
+}
+
+.settings-panel__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-panel__label {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.settings-panel__description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.settings-panel__field {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.settings-panel__field input[type='range'] {
+  flex: 1;
+}
+
+.settings-panel__field input[type='number'] {
+  width: 80px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text-primary);
+}
+
+.settings-panel__value {
+  font-weight: 600;
+}
+
+.settings-panel__tips {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  color: rgba(226, 232, 240, 0.75);
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
 .app-footer {
   width: min(1200px, 100% - 32px);
   margin: 0 auto 32px;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,10 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css'; // optional, create if you want basic styles
+import { SettingsProvider } from './hooks/useSettings';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <SettingsProvider>
+      <App />
+    </SettingsProvider>
   </React.StrictMode>
 );

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -70,3 +70,14 @@ export const formatCpuCores = (value) => {
   return numeric.toLocaleString();
 };
 
+export const formatMegabytes = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return '--';
+  }
+  if (numeric >= 1024) {
+    return `${(numeric / 1024).toFixed(2)} GB`;
+  }
+  return `${numeric.toFixed(1)} MB`;
+};
+


### PR DESCRIPTION
## Summary
- extend the metrics collector to capture top application usage and per-domain network throughput and expose them via the REST and WebSocket payloads
- add reusable settings state, configurable data retention, and new application/network analytics panels on the dashboard UI
- enhance payload normalisation, styling, and layout to surface the richer telemetry in detail and surface retention context in the header

## Testing
- npm run build
- cmake -S backend -B backend/build *(fails: Boost development headers are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c7d8b9888333945e0f7b52ea9ed7