### PR TITLE
Add metrics history snapshots and expose complete process/domain data

### DIFF
--- a/backend/src/system_metrics.cpp
+++ b/backend/src/system_metrics.cpp
@@ -479,12 +479,6 @@ std::vector<ApplicationUsage> MetricsCollector::read_application_usage()
         return lhs.pid < rhs.pid;
     });
 
-    constexpr std::size_t maxApplications = 8;
-    if (result.size() > maxApplications)
-    {
-        result.resize(maxApplications);
-    }
-
     return result;
 }
 
@@ -587,12 +581,6 @@ std::vector<DomainUsage> MetricsCollector::build_domain_usage(const ConnectionSu
         }
         return lhs.domain < rhs.domain;
     });
-
-    constexpr std::size_t maxDomains = 10;
-    if (result.size() > maxDomains)
-    {
-        result.resize(maxDomains);
-    }
 
     return result;
 }

--- a/frontend/src/components/AppHeader.js
+++ b/frontend/src/components/AppHeader.js
@@ -2,10 +2,31 @@ import React from 'react';
 
 import { connectionLabel, healthLabel } from '../constants/status';
 
-function AppHeader({ connectionState, health, onOpenSettings, retentionDays }) {
+function AppHeader({
+  connectionState,
+  health,
+  onOpenSettings,
+  onOpenHistory,
+  onSaveSnapshot,
+  retentionDays,
+  canSaveSnapshot,
+  historyCount
+}) {
   const handleOpenSettings = () => {
     if (typeof onOpenSettings === 'function') {
       onOpenSettings();
+    }
+  };
+
+  const handleOpenHistory = () => {
+    if (typeof onOpenHistory === 'function') {
+      onOpenHistory();
+    }
+  };
+
+  const handleSaveSnapshot = () => {
+    if (typeof onSaveSnapshot === 'function') {
+      onSaveSnapshot();
     }
   };
 
@@ -13,6 +34,8 @@ function AppHeader({ connectionState, health, onOpenSettings, retentionDays }) {
   const retentionLabel = Number.isFinite(retentionNumeric) && retentionNumeric > 0
     ? `${retentionNumeric} day${retentionNumeric === 1 ? '' : 's'}`
     : 'configurable retention';
+
+  const historyLabel = historyCount > 0 ? `History (${historyCount})` : 'History';
 
   return (
     <header className="app-header">
@@ -26,9 +49,27 @@ function AppHeader({ connectionState, health, onOpenSettings, retentionDays }) {
         </p>
       </div>
       <div className="app-header__status">
-        <button type="button" className="settings-button" onClick={handleOpenSettings}>
-          Dashboard settings
-        </button>
+        <div className="app-header__actions">
+          <button
+            type="button"
+            className="header-button"
+            onClick={handleSaveSnapshot}
+            disabled={!canSaveSnapshot}
+          >
+            Save snapshot
+          </button>
+          <button
+            type="button"
+            className="header-button header-button--ghost"
+            onClick={handleOpenHistory}
+            disabled={!historyCount}
+          >
+            {historyLabel}
+          </button>
+          <button type="button" className="header-button" onClick={handleOpenSettings}>
+            Dashboard settings
+          </button>
+        </div>
         <span className={`status-pill status-pill--${connectionState}`}>
           <span className="status-indicator" aria-hidden="true" />
           {connectionLabel[connectionState]}

--- a/frontend/src/components/ApplicationUsagePanel.js
+++ b/frontend/src/components/ApplicationUsagePanel.js
@@ -14,29 +14,31 @@ function ApplicationUsagePanel({ applications }) {
         </div>
       </div>
       {hasData ? (
-        <table className="detail-table" aria-label="Top application resource usage">
-          <thead>
-            <tr>
-              <th scope="col">Application</th>
-              <th scope="col">CPU</th>
-              <th scope="col">Memory</th>
-              <th scope="col">PID</th>
-            </tr>
-          </thead>
-          <tbody>
-            {applications.map((app) => (
-              <tr key={`${app.pid}-${app.name}`}>
-                <th scope="row">
-                  <div className="entity-name">{app.name || `Process ${app.pid}`}</div>
-                  <div className="entity-meta">PID {app.pid}</div>
-                </th>
-                <td>{formatPercentLabel(app.cpu)}</td>
-                <td>{formatMegabytes(app.memoryMb)}</td>
-                <td>{app.pid}</td>
+        <div className="panel__table-wrapper">
+          <table className="detail-table" aria-label="Top application resource usage">
+            <thead>
+              <tr>
+                <th scope="col">Application</th>
+                <th scope="col">CPU</th>
+                <th scope="col">Memory</th>
+                <th scope="col">PID</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {applications.map((app) => (
+                <tr key={`${app.pid}-${app.name}`}>
+                  <th scope="row">
+                    <div className="entity-name">{app.name || `Process ${app.pid}`}</div>
+                    <div className="entity-meta">PID {app.pid}</div>
+                  </th>
+                  <td>{formatPercentLabel(app.cpu)}</td>
+                  <td>{formatMegabytes(app.memoryMb)}</td>
+                  <td>{app.pid}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       ) : (
         <div className="panel__empty" role="status">
           <p>No processes sampled yet. Waiting for activity.</p>

--- a/frontend/src/components/DomainTrafficPanel.js
+++ b/frontend/src/components/DomainTrafficPanel.js
@@ -16,29 +16,31 @@ function DomainTrafficPanel({ domains, totalConnections, throughput }) {
         <div className="panel__helper" aria-live="polite">{summaryLabel}</div>
       </div>
       {hasData ? (
-        <table className="detail-table" aria-label="Network usage per domain">
-          <thead>
-            <tr>
-              <th scope="col">Remote domain</th>
-              <th scope="col">Connections</th>
-              <th scope="col">Inbound</th>
-              <th scope="col">Outbound</th>
-            </tr>
-          </thead>
-          <tbody>
-            {domains.map((domain) => (
-              <tr key={`${domain.domain}-${domain.connections}`}>
-                <th scope="row">
-                  <div className="entity-name">{domain.domain}</div>
-                  <div className="entity-meta">{formatConnections(domain.connections)} connections</div>
-                </th>
-                <td>{formatConnections(domain.connections)}</td>
-                <td>{formatThroughput(domain.receiveRate)}</td>
-                <td>{formatThroughput(domain.transmitRate)}</td>
+        <div className="panel__table-wrapper">
+          <table className="detail-table" aria-label="Network usage per domain">
+            <thead>
+              <tr>
+                <th scope="col">Remote domain</th>
+                <th scope="col">Connections</th>
+                <th scope="col">Inbound</th>
+                <th scope="col">Outbound</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {domains.map((domain) => (
+                <tr key={`${domain.domain}-${domain.connections}`}>
+                  <th scope="row">
+                    <div className="entity-name">{domain.domain}</div>
+                    <div className="entity-meta">{formatConnections(domain.connections)} connections</div>
+                  </th>
+                  <td>{formatConnections(domain.connections)}</td>
+                  <td>{formatThroughput(domain.receiveRate)}</td>
+                  <td>{formatThroughput(domain.transmitRate)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       ) : (
         <div className="panel__empty" role="status">
           <p>No network peers detected for the current sampling window.</p>

--- a/frontend/src/components/HistoryPanel.js
+++ b/frontend/src/components/HistoryPanel.js
@@ -1,0 +1,235 @@
+import React, { useEffect } from 'react';
+
+import {
+  formatConnections,
+  formatDateTime,
+  formatDuration,
+  formatMegabytes,
+  formatPercentLabel,
+  formatThroughput,
+  formatThroughputPair
+} from '../utils/formatters';
+
+const formatRangeLabel = (range) => {
+  const startLabel = range?.start ? formatDateTime(range.start) : 'Unknown start';
+  const endLabel = range?.end ? formatDateTime(range.end) : 'Unknown end';
+  const durationLabel = formatDuration(range?.start, range?.end);
+  return `${startLabel} → ${endLabel}${durationLabel ? ` · ${durationLabel}` : ''}`;
+};
+
+const renderStat = (label, value) => (
+  <div className="history-panel__stat" key={label}>
+    <dt>{label}</dt>
+    <dd>{value}</dd>
+  </div>
+);
+
+const renderStatGroup = (stats) => {
+  if (!stats) {
+    return null;
+  }
+
+  return (
+    <div className="history-panel__stats-grid">
+      {renderStat('CPU avg', formatPercentLabel(stats.cpu?.avg))}
+      {renderStat('CPU peak', formatPercentLabel(stats.cpu?.peak))}
+      {renderStat('Memory avg', formatPercentLabel(stats.memory?.avg))}
+      {renderStat('Memory peak', formatPercentLabel(stats.memory?.peak))}
+      {renderStat('Disk peak', formatPercentLabel(stats.disk?.peak))}
+      {renderStat('Connections peak', formatConnections(stats.connections?.peak))}
+      {renderStat('Network inbound peak', formatThroughput(stats.netRx?.peak))}
+      {renderStat('Network outbound peak', formatThroughput(stats.netTx?.peak))}
+    </div>
+  );
+};
+
+const renderApplications = (applications) => {
+  if (!Array.isArray(applications) || applications.length === 0) {
+    return <p className="history-panel__empty-row">No application data was captured in this snapshot.</p>;
+  }
+
+  return (
+    <div className="panel__table-wrapper">
+      <table className="detail-table" aria-label="Snapshot application usage">
+        <thead>
+          <tr>
+            <th scope="col">Application</th>
+            <th scope="col">CPU</th>
+            <th scope="col">Memory</th>
+            <th scope="col">PID</th>
+          </tr>
+        </thead>
+        <tbody>
+          {applications.map((app) => (
+            <tr key={`${app.pid}-${app.name}`}>
+              <th scope="row">
+                <div className="entity-name">{app.name || `Process ${app.pid}`}</div>
+                <div className="entity-meta">PID {app.pid}</div>
+              </th>
+              <td>{formatPercentLabel(app.cpu)}</td>
+              <td>{formatMegabytes(app.memoryMb)}</td>
+              <td>{app.pid}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const renderDomains = (domains) => {
+  if (!Array.isArray(domains) || domains.length === 0) {
+    return <p className="history-panel__empty-row">No remote domains were observed for this snapshot.</p>;
+  }
+
+  return (
+    <div className="panel__table-wrapper">
+      <table className="detail-table" aria-label="Snapshot domain usage">
+        <thead>
+          <tr>
+            <th scope="col">Domain</th>
+            <th scope="col">Connections</th>
+            <th scope="col">Inbound</th>
+            <th scope="col">Outbound</th>
+          </tr>
+        </thead>
+        <tbody>
+          {domains.map((domain) => (
+            <tr key={`${domain.domain}-${domain.connections}`}>
+              <th scope="row">
+                <div className="entity-name">{domain.domain}</div>
+                <div className="entity-meta">{formatConnections(domain.connections)} connections</div>
+              </th>
+              <td>{formatConnections(domain.connections)}</td>
+              <td>{formatThroughput(domain.receiveRate)}</td>
+              <td>{formatThroughput(domain.transmitRate)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+function HistoryPanel({
+  open,
+  onClose,
+  snapshots,
+  onDeleteSnapshot,
+  onClearSnapshots,
+  onExportSnapshot
+}) {
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  return (
+    <div className={`history-panel ${open ? 'history-panel--open' : ''}`} aria-hidden={!open}>
+      <div className="history-panel__backdrop" role="presentation" onClick={onClose} />
+      <aside
+        className="history-panel__surface"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="history-panel-title"
+      >
+        <header className="history-panel__header">
+          <div>
+            <p className="history-panel__eyebrow">Historical snapshots</p>
+            <h2 id="history-panel-title">Telemetry history</h2>
+            <p className="history-panel__summary">
+              Saved datasets capture the full application list, network domains and raw samples from the live stream.
+              Export entries for offline analysis or remove them to reclaim local storage.
+            </p>
+          </div>
+          <div className="history-panel__actions">
+            <button
+              type="button"
+              className="history-panel__action"
+              onClick={onClearSnapshots}
+              disabled={!snapshots?.length}
+            >
+              Clear all
+            </button>
+            <button type="button" className="history-panel__close" onClick={onClose}>
+              Close
+            </button>
+          </div>
+        </header>
+        <div className="history-panel__content">
+          {snapshots?.length ? (
+            <ul className="history-panel__list">
+              {snapshots.map((snapshot) => (
+                <li key={snapshot.id} className="history-panel__item">
+                  <header className="history-panel__item-header">
+                    <div>
+                      <h3>Snapshot saved {formatDateTime(snapshot.savedAt)}</h3>
+                      <p>{formatRangeLabel(snapshot.range)}</p>
+                    </div>
+                    <div className="history-panel__item-meta">
+                      <span>{snapshot.sampleCount.toLocaleString()} samples</span>
+                      <span>{formatThroughputPair(snapshot.latestMetric?.netRx, snapshot.latestMetric?.netTx)}</span>
+                    </div>
+                  </header>
+
+                  <section aria-label="Resource summary" className="history-panel__section">
+                    <h4>Resource summary</h4>
+                    <dl className="history-panel__stats">{renderStatGroup(snapshot.stats)}</dl>
+                  </section>
+
+                  <section aria-label="Application utilisation" className="history-panel__section">
+                    <h4>Application utilisation</h4>
+                    {renderApplications(snapshot.applications)}
+                  </section>
+
+                  <section aria-label="Network domains" className="history-panel__section">
+                    <h4>Observed domains</h4>
+                    {renderDomains(snapshot.domains)}
+                  </section>
+
+                  <footer className="history-panel__item-footer">
+                    <div className="history-panel__item-actions">
+                      <button
+                        type="button"
+                        className="history-panel__action"
+                        onClick={() => onExportSnapshot(snapshot)}
+                      >
+                        Download JSON
+                      </button>
+                      <button
+                        type="button"
+                        className="history-panel__action history-panel__action--danger"
+                        onClick={() => onDeleteSnapshot(snapshot.id)}
+                      >
+                        Remove snapshot
+                      </button>
+                    </div>
+                  </footer>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="history-panel__empty" role="status">
+              <p>No snapshots captured yet. Use the “Save snapshot” action in the dashboard header to archive the current session.</p>
+            </div>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+export default HistoryPanel;
+

--- a/frontend/src/hooks/useMetricsHistory.js
+++ b/frontend/src/hooks/useMetricsHistory.js
@@ -1,0 +1,150 @@
+import { useCallback, useMemo, useState } from 'react';
+
+const STORAGE_KEY = 'monitoring.history.snapshots.v1';
+const MAX_SNAPSHOTS = 25;
+
+const cloneValue = (value) => {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (error) {
+    return value;
+  }
+};
+
+const readStoredSnapshots = () => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed;
+  } catch (error) {
+    return [];
+  }
+};
+
+const persistSnapshots = (snapshots) => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshots));
+  } catch (error) {
+    // Swallow storage errors (e.g. quota exceeded) to avoid breaking the UI.
+  }
+};
+
+const createSnapshot = (metrics, latestMetric, stats) => {
+  if (!Array.isArray(metrics) || metrics.length === 0) {
+    return undefined;
+  }
+
+  const clonedMetrics = cloneValue(metrics);
+  const safeLatest = cloneValue(latestMetric ?? {});
+  const safeStats = cloneValue(stats ?? {});
+
+  const first = metrics[0];
+  const last = metrics[metrics.length - 1];
+
+  const range = {
+    start: first?.timestamp ?? null,
+    end: last?.timestamp ?? null
+  };
+
+  return {
+    id: `snapshot-${Date.now()}`,
+    savedAt: new Date().toISOString(),
+    sampleCount: metrics.length,
+    range,
+    stats: safeStats,
+    latestMetric: safeLatest,
+    applications: cloneValue(safeLatest?.applications ?? []),
+    domains: cloneValue(safeLatest?.domains ?? []),
+    metrics: clonedMetrics
+  };
+};
+
+export const useMetricsHistory = ({ metrics, latestMetric, stats }) => {
+  const [snapshots, setSnapshots] = useState(() => readStoredSnapshots());
+
+  const saveSnapshot = useCallback(() => {
+    const snapshot = createSnapshot(metrics, latestMetric, stats);
+    if (!snapshot) {
+      return undefined;
+    }
+
+    setSnapshots((previous) => {
+      const next = [snapshot, ...previous];
+      if (next.length > MAX_SNAPSHOTS) {
+        next.length = MAX_SNAPSHOTS;
+      }
+      persistSnapshots(next);
+      return next;
+    });
+
+    return snapshot;
+  }, [metrics, latestMetric, stats]);
+
+  const deleteSnapshot = useCallback((id) => {
+    setSnapshots((previous) => {
+      const next = previous.filter((item) => item.id !== id);
+      persistSnapshots(next);
+      return next;
+    });
+  }, []);
+
+  const clearSnapshots = useCallback(() => {
+    setSnapshots(() => {
+      persistSnapshots([]);
+      return [];
+    });
+  }, []);
+
+  const exportSnapshot = useCallback((snapshot) => {
+    if (typeof window === 'undefined' || typeof document === 'undefined' || !snapshot) {
+      return;
+    }
+
+    const data = JSON.stringify(snapshot, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `${snapshot.id || 'snapshot'}.json`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+
+    URL.revokeObjectURL(url);
+  }, []);
+
+  const sortedSnapshots = useMemo(() => {
+    return [...snapshots].sort((a, b) => {
+      const left = new Date(a.savedAt).getTime();
+      const right = new Date(b.savedAt).getTime();
+      if (Number.isNaN(left) || Number.isNaN(right)) {
+        return 0;
+      }
+      return right - left;
+    });
+  }, [snapshots]);
+
+  return {
+    snapshots: sortedSnapshots,
+    saveSnapshot,
+    deleteSnapshot,
+    clearSnapshots,
+    exportSnapshot
+  };
+};
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -106,6 +106,14 @@ a {
   align-items: flex-end;
 }
 
+.app-header__actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .status-pill {
   display: inline-flex;
   align-items: center;
@@ -533,6 +541,7 @@ a {
   color: rgba(226, 232, 240, 0.85);
 }
 
+.header-button,
 .settings-button {
   border: none;
   border-radius: 999px;
@@ -546,10 +555,28 @@ a {
   backdrop-filter: blur(8px);
 }
 
+.header-button:hover,
+.header-button:focus,
 .settings-button:hover,
 .settings-button:focus {
   background: rgba(148, 163, 184, 0.4);
   transform: translateY(-1px);
+}
+
+.header-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  transform: none;
+}
+
+.header-button--ghost {
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.header-button--ghost:hover,
+.header-button--ghost:focus {
+  background: rgba(148, 163, 184, 0.2);
 }
 
 .panel__helper {
@@ -614,6 +641,18 @@ a {
   border-top: 1px solid rgba(148, 163, 184, 0.18);
   font-size: 0.85rem;
   color: var(--text-surface-muted);
+}
+
+.panel__table-wrapper {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  overflow: auto;
+  max-height: 340px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.panel__table-wrapper .detail-table {
+  margin: 0;
 }
 
 .settings-panel {
@@ -729,6 +768,234 @@ a {
   line-height: 1.6;
 }
 
+.history-panel {
+  position: fixed;
+  inset: 0;
+  display: none;
+  z-index: 45;
+}
+
+.history-panel--open {
+  display: block;
+}
+
+.history-panel__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(6px);
+}
+
+.history-panel__surface {
+  position: absolute;
+  inset: 40px;
+  margin: auto;
+  width: min(960px, 100%);
+  height: min(92vh, 100%);
+  background: rgba(15, 23, 42, 0.97);
+  color: var(--text-primary);
+  border-radius: 24px;
+  box-shadow: 0 32px 90px -45px rgba(15, 23, 42, 0.85);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.history-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 32px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.history-panel__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.75);
+  margin: 0 0 8px;
+}
+
+.history-panel__summary {
+  margin-top: 8px;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.history-panel__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.history-panel__action {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.1);
+  color: var(--text-primary);
+  padding: 8px 16px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.history-panel__action:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  transform: none;
+}
+
+.history-panel__action:hover,
+.history-panel__action:focus {
+  background: rgba(148, 163, 184, 0.2);
+  transform: translateY(-1px);
+}
+
+.history-panel__action--danger {
+  border-color: rgba(239, 68, 68, 0.45);
+  color: #fecaca;
+}
+
+.history-panel__action--danger:hover,
+.history-panel__action--danger:focus {
+  background: rgba(239, 68, 68, 0.16);
+}
+
+.history-panel__close {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: transparent;
+  color: var(--text-primary);
+  padding: 8px 18px;
+  cursor: pointer;
+}
+
+.history-panel__close:hover,
+.history-panel__close:focus {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.history-panel__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 32px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.history-panel__empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: 20px;
+  padding: 32px;
+  color: rgba(226, 232, 240, 0.75);
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.history-panel__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.history-panel__item {
+  background: rgba(15, 23, 42, 0.82);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: var(--shadow-card);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.history-panel__item-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.history-panel__item-header h3 {
+  margin: 0 0 4px;
+}
+
+.history-panel__item-header p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.history-panel__item-meta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.history-panel__section h4 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.history-panel__stats {
+  margin: 0;
+}
+
+.history-panel__stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px 16px;
+}
+
+.history-panel__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.history-panel__stat dt {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.history-panel__stat dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.history-panel__empty-row {
+  margin: 0;
+  padding: 12px 0;
+  color: rgba(226, 232, 240, 0.75);
+  font-style: italic;
+}
+
+.history-panel__item-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.history-panel__item-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .app-footer {
   width: min(1200px, 100% - 32px);
   margin: 0 auto 32px;
@@ -747,6 +1014,10 @@ a {
   .app-header__status {
     flex-direction: row;
     align-items: center;
+  }
+
+  .app-header__actions {
+    justify-content: flex-start;
   }
 
   .panel-grid {
@@ -774,6 +1045,10 @@ a {
   .timeline__content {
     padding: 14px 16px;
   }
+
+  .history-panel__surface {
+    inset: 24px;
+  }
 }
 
 @media (max-width: 540px) {
@@ -782,7 +1057,16 @@ a {
     align-items: flex-start;
   }
 
+  .app-header__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
   .metric-card {
     min-height: 150px;
+  }
+
+  .history-panel__surface {
+    inset: 16px;
   }
 }

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -81,3 +81,56 @@ export const formatMegabytes = (value) => {
   return `${numeric.toFixed(1)} MB`;
 };
 
+const normaliseDate = (value) => {
+  if (!value) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date;
+};
+
+export const formatDateTime = (value) => {
+  const date = normaliseDate(value);
+  if (!date) {
+    return '--';
+  }
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  });
+};
+
+export const formatDuration = (start, end) => {
+  const startDate = normaliseDate(start);
+  const endDate = normaliseDate(end);
+  if (!startDate || !endDate) {
+    return '';
+  }
+
+  const diff = Math.max(0, endDate.getTime() - startDate.getTime());
+  const totalSeconds = Math.floor(diff / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts = [];
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes > 0) {
+    parts.push(`${minutes}m`);
+  }
+  if (seconds > 0 || parts.length === 0) {
+    parts.push(`${seconds}s`);
+  }
+
+  return parts.join(' ');
+};
+


### PR DESCRIPTION
## Summary
- expose the entire process list and network domain usage data from the metrics service
- add client-side metric snapshot archiving with a history drawer and export controls
- refresh dashboard tables and header actions to surface all applications, domains, and history tools

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5d7dac68c8333b7070a3162f11411