### PR TITLE
Enhance monitoring with security and Docker insights

### DIFF
--- a/backend/src/rest_server.cpp
+++ b/backend/src/rest_server.cpp
@@ -47,7 +47,9 @@ void RestServer::handle_get(web::http::http_request request)
     SystemMetrics m = collector.collect();
     web::json::value response;
     response[utility::conversions::to_string_t("cpu")] = web::json::value::number(m.cpuUsage);
+    response[utility::conversions::to_string_t("cpuAvg")] = web::json::value::number(m.cpuUsageAverage);
     response[utility::conversions::to_string_t("memory")] = web::json::value::number(m.memoryUsage);
+    response[utility::conversions::to_string_t("swap")] = web::json::value::number(m.swapUsage);
     response[utility::conversions::to_string_t("connections")] = web::json::value::number(m.activeConnections);
     response[utility::conversions::to_string_t("disk")] = web::json::value::number(m.diskUsage);
     response[utility::conversions::to_string_t("load1")] = web::json::value::number(m.loadAverage1);
@@ -55,7 +57,16 @@ void RestServer::handle_get(web::http::http_request request)
     response[utility::conversions::to_string_t("load15")] = web::json::value::number(m.loadAverage15);
     response[utility::conversions::to_string_t("netRx")] = web::json::value::number(m.networkReceiveRate);
     response[utility::conversions::to_string_t("netTx")] = web::json::value::number(m.networkTransmitRate);
+    response[utility::conversions::to_string_t("netRxAvg")] = web::json::value::number(m.networkReceiveRateAverage);
+    response[utility::conversions::to_string_t("netTxAvg")] = web::json::value::number(m.networkTransmitRateAverage);
     response[utility::conversions::to_string_t("cpuCores")] = web::json::value::number(m.cpuCount);
+    response[utility::conversions::to_string_t("processes")] = web::json::value::number(m.processCount);
+    response[utility::conversions::to_string_t("threads")] = web::json::value::number(m.threadCount);
+    response[utility::conversions::to_string_t("listeningTcp")] = web::json::value::number(m.listeningTcp);
+    response[utility::conversions::to_string_t("listeningUdp")] = web::json::value::number(m.listeningUdp);
+    response[utility::conversions::to_string_t("openFds")] = web::json::value::number(static_cast<double>(m.openFileDescriptors));
+    response[utility::conversions::to_string_t("uniqueDomains")] = web::json::value::number(static_cast<double>(m.uniqueDomains));
+    response[utility::conversions::to_string_t("dockerAvailable")] = web::json::value::boolean(m.dockerAvailable);
     response[utility::conversions::to_string_t("timestamp")] = web::json::value::string(utility::conversions::to_string_t(MetricsCollector::to_iso8601(m.timestamp)));
 
     web::json::value applications = web::json::value::array(m.topApplications.size());
@@ -83,6 +94,32 @@ void RestServer::handle_get(web::http::http_request request)
         domains[i] = std::move(item);
     }
     response[utility::conversions::to_string_t("domains")] = std::move(domains);
+
+    web::json::value dockerContainers = web::json::value::array(m.dockerContainers.size());
+    for (std::size_t i = 0; i < m.dockerContainers.size(); ++i)
+    {
+        const auto &container = m.dockerContainers[i];
+        web::json::value item;
+        item[utility::conversions::to_string_t("id")] = web::json::value::string(utility::conversions::to_string_t(container.id));
+        item[utility::conversions::to_string_t("name")] = web::json::value::string(utility::conversions::to_string_t(container.name));
+        item[utility::conversions::to_string_t("image")] = web::json::value::string(utility::conversions::to_string_t(container.image));
+        item[utility::conversions::to_string_t("status")] = web::json::value::string(utility::conversions::to_string_t(container.status));
+        dockerContainers[i] = std::move(item);
+    }
+    response[utility::conversions::to_string_t("dockerContainers")] = std::move(dockerContainers);
+
+    web::json::value dockerImages = web::json::value::array(m.dockerImages.size());
+    for (std::size_t i = 0; i < m.dockerImages.size(); ++i)
+    {
+        const auto &image = m.dockerImages[i];
+        web::json::value item;
+        item[utility::conversions::to_string_t("repository")] = web::json::value::string(utility::conversions::to_string_t(image.repository));
+        item[utility::conversions::to_string_t("tag")] = web::json::value::string(utility::conversions::to_string_t(image.tag));
+        item[utility::conversions::to_string_t("id")] = web::json::value::string(utility::conversions::to_string_t(image.id));
+        item[utility::conversions::to_string_t("size")] = web::json::value::string(utility::conversions::to_string_t(image.size));
+        dockerImages[i] = std::move(item);
+    }
+    response[utility::conversions::to_string_t("dockerImages")] = std::move(dockerImages);
 
     web::http::http_response httpResponse(web::http::status_codes::OK);
     httpResponse.headers().add(web::http::header_names::cache_control, utility::conversions::to_string_t("no-store"));

--- a/backend/src/system_metrics.h
+++ b/backend/src/system_metrics.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <array>
 #include <chrono>
+#include <deque>
 #include <tuple>
 #include <mutex>
 #include <string>
@@ -24,6 +25,22 @@ struct DomainUsage
     int connections;
 };
 
+struct DockerContainerSummary
+{
+    std::string id;
+    std::string name;
+    std::string image;
+    std::string status;
+};
+
+struct DockerImageSummary
+{
+    std::string repository;
+    std::string tag;
+    std::string id;
+    std::string size;
+};
+
 struct SystemMetrics
 {
     double cpuUsage;       // CPU usage in %
@@ -35,10 +52,23 @@ struct SystemMetrics
     double loadAverage15;  // Load average for the last 15 minutes
     double networkReceiveRate; // Inbound network throughput in KB/s
     double networkTransmitRate; // Outbound network throughput in KB/s
+    double networkReceiveRateAverage; // Rolling average inbound throughput in KB/s
+    double networkTransmitRateAverage; // Rolling average outbound throughput in KB/s
+    double cpuUsageAverage; // Rolling average CPU usage in %
+    double swapUsage;      // Swap usage in %
     unsigned int cpuCount;     // Number of logical CPU cores
+    unsigned int processCount; // Total number of running processes
+    unsigned int threadCount;  // Total number of threads across processes
+    unsigned int listeningTcp; // TCP listening sockets
+    unsigned int listeningUdp; // UDP listening sockets
+    unsigned long openFileDescriptors; // Open file descriptors reported by kernel
+    std::size_t uniqueDomains;         // Unique remote domains observed
     std::chrono::system_clock::time_point timestamp; // Collection time
     std::vector<ApplicationUsage> topApplications;    // Top processes by utilisation
     std::vector<DomainUsage> domainUsage;             // Aggregated network usage per domain
+    bool dockerAvailable;                              // Whether Docker CLI is accessible
+    std::vector<DockerContainerSummary> dockerContainers; // Running Docker containers
+    std::vector<DockerImageSummary> dockerImages;         // Available Docker images
 };
 
 class MetricsCollector
@@ -58,6 +88,7 @@ private:
 
     double read_cpu_usage();
     double read_memory_usage();
+    double read_swap_usage();
     std::vector<ApplicationUsage> read_application_usage();
     ConnectionSummary read_connection_summary();
     std::vector<DomainUsage> build_domain_usage(const ConnectionSummary &summary, double totalRx, double totalTx) const;
@@ -66,6 +97,15 @@ private:
     std::array<double, 3> read_load_averages() const;
     unsigned int detect_cpu_count();
     unsigned int query_cpu_count() const;
+    std::pair<unsigned int, unsigned int> read_process_thread_counts();
+    std::pair<unsigned int, unsigned int> read_listening_ports() const;
+    unsigned long read_open_file_descriptors() const;
+    void update_rollup_samples(double cpu, double rx, double tx, const std::chrono::steady_clock::time_point &now);
+    double compute_average(std::deque<std::pair<std::chrono::steady_clock::time_point, double>> &samples,
+                           const std::chrono::steady_clock::time_point &now,
+                           const std::chrono::steady_clock::duration &window) const;
+    std::pair<std::vector<DockerContainerSummary>, std::vector<DockerImageSummary>> read_docker_inventory(bool &available) const;
+    std::string resolve_hostname(const std::string &address, bool ipv6);
 
     std::mutex mutex_;
     bool cpu_initialized_;
@@ -82,4 +122,8 @@ private:
     std::chrono::steady_clock::time_point last_collection_time_;
     SystemMetrics cached_metrics_;
     std::unordered_map<int, unsigned long long> process_cpu_times_;
+    std::deque<std::pair<std::chrono::steady_clock::time_point, double>> cpu_samples_;
+    std::deque<std::pair<std::chrono::steady_clock::time_point, double>> rx_samples_;
+    std::deque<std::pair<std::chrono::steady_clock::time_point, double>> tx_samples_;
+    std::unordered_map<std::string, std::string> dns_cache_;
 };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,6 +14,8 @@ import { useMetricsHistory } from './hooks/useMetricsHistory';
 import { useSettings } from './hooks/useSettings';
 import { buildStatistics } from './utils/statistics';
 import DomainTrafficPanel from './components/DomainTrafficPanel';
+import SecurityOverview from './components/SecurityOverview';
+import DockerResourcesPanel from './components/DockerResourcesPanel';
 
 function App() {
   const { retentionSeconds, retentionDays, updateSetting } = useSettings();
@@ -106,6 +108,15 @@ function App() {
             domains={latestMetric?.domains ?? []}
             totalConnections={latestMetric?.connections}
             throughput={{ inbound: latestMetric?.netRx, outbound: latestMetric?.netTx }}
+          />
+        </section>
+
+        <section className="panel-grid panel-grid--balanced" aria-label="Security and developer tooling">
+          <SecurityOverview latestMetric={latestMetric} />
+          <DockerResourcesPanel
+            dockerAvailable={latestMetric?.dockerAvailable}
+            containers={latestMetric?.dockerContainers ?? []}
+            images={latestMetric?.dockerImages ?? []}
           />
         </section>
       </main>

--- a/frontend/src/components/DockerResourcesPanel.js
+++ b/frontend/src/components/DockerResourcesPanel.js
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import { formatBoolean, formatCount } from '../utils/formatters';
+
+function DockerResourcesPanel({ dockerAvailable, containers, images }) {
+  const hasContainers = Array.isArray(containers) && containers.length > 0;
+  const hasImages = Array.isArray(images) && images.length > 0;
+
+  return (
+    <article className="panel">
+      <div className="panel__header">
+        <div>
+          <h2>Docker resources</h2>
+          <p>Runtime inventory for local container workloads.</p>
+        </div>
+        <div className="panel__helper" aria-live="polite">
+          CLI available: {formatBoolean(dockerAvailable)}
+        </div>
+      </div>
+      {dockerAvailable ? (
+        <>
+          <section aria-label="Running containers">
+            <h3>Containers ({formatCount(containers?.length ?? 0)})</h3>
+            {hasContainers ? (
+              <div className="panel__table-wrapper">
+                <table className="detail-table" aria-label="Docker containers">
+                  <thead>
+                    <tr>
+                      <th scope="col">Name</th>
+                      <th scope="col">Image</th>
+                      <th scope="col">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {containers.map((container) => (
+                      <tr key={container.id || container.name}>
+                        <th scope="row">
+                          <div className="entity-name">{container.name || container.id || 'Unnamed container'}</div>
+                          <div className="entity-meta">{container.id}</div>
+                        </th>
+                        <td>{container.image || 'Unknown image'}</td>
+                        <td>{container.status || 'Unknown'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="panel__empty" role="status">
+                <p>No running containers detected.</p>
+              </div>
+            )}
+          </section>
+          <section aria-label="Available images">
+            <h3>Images ({formatCount(images?.length ?? 0)})</h3>
+            {hasImages ? (
+              <div className="panel__table-wrapper">
+                <table className="detail-table" aria-label="Docker images">
+                  <thead>
+                    <tr>
+                      <th scope="col">Repository</th>
+                      <th scope="col">Tag</th>
+                      <th scope="col">Size</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {images.map((image) => (
+                      <tr key={`${image.repository}-${image.id}`}>
+                        <th scope="row">
+                          <div className="entity-name">{image.repository || 'Unnamed repo'}</div>
+                          <div className="entity-meta">{image.id}</div>
+                        </th>
+                        <td>{image.tag || 'latest'}</td>
+                        <td>{image.size || 'Unknown'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="panel__empty" role="status">
+                <p>No Docker images reported.</p>
+              </div>
+            )}
+          </section>
+        </>
+      ) : (
+        <div className="panel__empty" role="status">
+          <p>Docker CLI is not available or not accessible for this user.</p>
+        </div>
+      )}
+    </article>
+  );
+}
+
+export default DockerResourcesPanel;

--- a/frontend/src/components/KpiGrid.js
+++ b/frontend/src/components/KpiGrid.js
@@ -3,6 +3,7 @@ import React from 'react';
 import MetricCard from './MetricCard';
 import {
   formatConnections,
+  formatCount,
   formatPercent,
   formatThroughput,
   formatThroughputPair
@@ -72,6 +73,90 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
           stats.netRx?.avg !== null && stats.netTx?.avg !== null
             ? `Avg ↓${formatThroughput(stats.netRx.avg)} • ↑${formatThroughput(stats.netTx.avg)}`
             : 'Waiting for samples'
+        }
+      />
+      <MetricCard
+        title="CPU avg (60s)"
+        value={formatPercent(latestMetric?.cpuAvg)}
+        unit="%"
+        status={health}
+        trend={buildTrend(latestMetric, previousMetric, 'cpuAvg', '%')}
+        helper={
+          stats.cpuAvg?.avg !== null
+            ? `Session avg ${formatPercent(stats.cpuAvg.avg)}%`
+            : 'Waiting for samples'
+        }
+      />
+      <MetricCard
+        title="Swap usage"
+        value={formatPercent(latestMetric?.swap)}
+        unit="%"
+        status={health}
+        trend={buildTrend(latestMetric, previousMetric, 'swap', '%')}
+        helper={
+          stats.swap?.avg !== null
+            ? `Avg ${formatPercent(stats.swap.avg)}% • Peak ${formatPercent(stats.swap.peak)}%`
+            : 'Waiting for samples'
+        }
+      />
+      <MetricCard
+        title="Processes"
+        value={formatCount(latestMetric?.processes)}
+        unit=""
+        status={health}
+        trend={buildTrend(latestMetric, previousMetric, 'processes', '')}
+        helper={
+          stats.processes?.avg !== null
+            ? `Avg ${formatCount(Math.round(stats.processes.avg))} • Peak ${formatCount(Math.round(stats.processes.peak))}`
+            : 'Waiting for samples'
+        }
+      />
+      <MetricCard
+        title="Threads"
+        value={formatCount(latestMetric?.threads)}
+        unit=""
+        status={health}
+        trend={buildTrend(latestMetric, previousMetric, 'threads', '')}
+        helper={
+          stats.threads?.avg !== null
+            ? `Avg ${formatCount(Math.round(stats.threads.avg))} • Peak ${formatCount(Math.round(stats.threads.peak))}`
+            : 'Waiting for samples'
+        }
+      />
+      <MetricCard
+        title="Listening sockets"
+        value={`${formatCount(latestMetric?.listeningTcp)} / ${formatCount(latestMetric?.listeningUdp)}`}
+        unit="TCP / UDP"
+        status={health}
+        trend={null}
+        helper={
+          stats.listeningTcp?.avg !== null && stats.listeningUdp?.avg !== null
+            ? `Avg TCP ${formatCount(Math.round(stats.listeningTcp.avg))} • UDP ${formatCount(Math.round(stats.listeningUdp.avg))}`
+            : 'Waiting for samples'
+        }
+      />
+      <MetricCard
+        title="Unique domains"
+        value={formatCount(latestMetric?.uniqueDomains)}
+        unit=""
+        status={health}
+        trend={buildTrend(latestMetric, previousMetric, 'uniqueDomains', '')}
+        helper={
+          stats.uniqueDomains?.avg !== null
+            ? `Avg ${formatCount(Math.round(stats.uniqueDomains.avg))} • Peak ${formatCount(Math.round(stats.uniqueDomains.peak))}`
+            : 'Waiting for samples'
+        }
+      />
+      <MetricCard
+        title="Docker containers"
+        value={formatCount(latestMetric?.dockerContainers?.length ?? 0)}
+        unit=""
+        status={latestMetric?.dockerAvailable ? 'healthy' : 'warning'}
+        trend={null}
+        helper={
+          latestMetric?.dockerAvailable
+            ? `${formatCount(latestMetric?.dockerImages?.length ?? 0)} images discovered`
+            : 'Docker CLI unavailable'
         }
       />
     </section>

--- a/frontend/src/components/PerformanceSummary.js
+++ b/frontend/src/components/PerformanceSummary.js
@@ -5,6 +5,7 @@ import {
   formatCpuCores,
   formatLoad,
   formatLoadPerCore,
+  formatPercent,
   formatPercentLabel,
   formatThroughput
 } from '../utils/formatters';
@@ -74,6 +75,60 @@ function PerformanceSummary({ latestMetric, stats }) {
               <td>{stats.netTx?.peak !== null ? formatThroughput(stats.netTx.peak) : '--'}</td>
             </tr>
             <tr>
+              <th scope="row">Avg net in (30s)</th>
+              <td>{formatThroughput(latestMetric?.netRxAvg)}</td>
+              <td>{stats.netRxAvg?.avg !== null ? formatThroughput(stats.netRxAvg.avg) : '--'}</td>
+              <td>{stats.netRxAvg?.peak !== null ? formatThroughput(stats.netRxAvg.peak) : '--'}</td>
+            </tr>
+            <tr>
+              <th scope="row">Avg net out (30s)</th>
+              <td>{formatThroughput(latestMetric?.netTxAvg)}</td>
+              <td>{stats.netTxAvg?.avg !== null ? formatThroughput(stats.netTxAvg.avg) : '--'}</td>
+              <td>{stats.netTxAvg?.peak !== null ? formatThroughput(stats.netTxAvg.peak) : '--'}</td>
+            </tr>
+            <tr>
+              <th scope="row">Swap</th>
+              <td>{formatPercentLabel(latestMetric?.swap)}</td>
+              <td>{stats.swap?.avg !== null ? formatPercentLabel(stats.swap.avg) : '--'}</td>
+              <td>{stats.swap?.peak !== null ? formatPercentLabel(stats.swap.peak) : '--'}</td>
+            </tr>
+            <tr>
+              <th scope="row">Processes</th>
+              <td>{formatConnections(latestMetric?.processes)}</td>
+              <td>{stats.processes?.avg !== null ? formatConnections(Math.round(stats.processes.avg)) : '--'}</td>
+              <td>{stats.processes?.peak !== null ? formatConnections(Math.round(stats.processes.peak)) : '--'}</td>
+            </tr>
+            <tr>
+              <th scope="row">Threads</th>
+              <td>{formatConnections(latestMetric?.threads)}</td>
+              <td>{stats.threads?.avg !== null ? formatConnections(Math.round(stats.threads.avg)) : '--'}</td>
+              <td>{stats.threads?.peak !== null ? formatConnections(Math.round(stats.threads.peak)) : '--'}</td>
+            </tr>
+            <tr>
+              <th scope="row">Listening TCP</th>
+              <td>{formatConnections(latestMetric?.listeningTcp)}</td>
+              <td>{stats.listeningTcp?.avg !== null ? formatConnections(Math.round(stats.listeningTcp.avg)) : '--'}</td>
+              <td>{stats.listeningTcp?.peak !== null ? formatConnections(Math.round(stats.listeningTcp.peak)) : '--'}</td>
+            </tr>
+            <tr>
+              <th scope="row">Listening UDP</th>
+              <td>{formatConnections(latestMetric?.listeningUdp)}</td>
+              <td>{stats.listeningUdp?.avg !== null ? formatConnections(Math.round(stats.listeningUdp.avg)) : '--'}</td>
+              <td>{stats.listeningUdp?.peak !== null ? formatConnections(Math.round(stats.listeningUdp.peak)) : '--'}</td>
+            </tr>
+            <tr>
+              <th scope="row">Open file descriptors</th>
+              <td>{formatConnections(latestMetric?.openFds)}</td>
+              <td>{stats.openFds?.avg !== null ? formatConnections(Math.round(stats.openFds.avg)) : '--'}</td>
+              <td>{stats.openFds?.peak !== null ? formatConnections(Math.round(stats.openFds.peak)) : '--'}</td>
+            </tr>
+            <tr>
+              <th scope="row">Unique domains</th>
+              <td>{formatConnections(latestMetric?.uniqueDomains)}</td>
+              <td>{stats.uniqueDomains?.avg !== null ? formatConnections(Math.round(stats.uniqueDomains.avg)) : '--'}</td>
+              <td>{stats.uniqueDomains?.peak !== null ? formatConnections(Math.round(stats.uniqueDomains.peak)) : '--'}</td>
+            </tr>
+            <tr>
               <th scope="row">Load 1m</th>
               <td>{formatLoad(latestMetric?.load1)}</td>
               <td>{stats.load1?.avg !== null ? formatLoad(stats.load1.avg) : '--'}</td>
@@ -109,6 +164,18 @@ function PerformanceSummary({ latestMetric, stats }) {
             <p className="insights-meta__value">
               {formatLoadPerCore(latestMetric?.load5, latestMetric?.cpuCores)}
             </p>
+          </div>
+          <div className="insights-meta__item" role="listitem">
+            <p className="insights-meta__label">Docker containers</p>
+            <p className="insights-meta__value">
+              {latestMetric?.dockerAvailable
+                ? `${formatConnections(latestMetric?.dockerContainers?.length ?? 0)} running`
+                : 'Unavailable'}
+            </p>
+          </div>
+          <div className="insights-meta__item" role="listitem">
+            <p className="insights-meta__label">30s CPU average</p>
+            <p className="insights-meta__value">{formatPercent(latestMetric?.cpuAvg)}%</p>
           </div>
         </div>
       </div>

--- a/frontend/src/components/SecurityOverview.js
+++ b/frontend/src/components/SecurityOverview.js
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { formatCount, formatConnections, formatThroughput } from '../utils/formatters';
+
+function SecurityOverview({ latestMetric }) {
+  const tcpListeners = formatCount(latestMetric?.listeningTcp);
+  const udpListeners = formatCount(latestMetric?.listeningUdp);
+  const uniqueDomains = formatCount(latestMetric?.uniqueDomains);
+  const openFds = formatCount(latestMetric?.openFds);
+  const processes = formatCount(latestMetric?.processes);
+  const threads = formatCount(latestMetric?.threads);
+  const avgInbound = formatThroughput(latestMetric?.netRxAvg);
+  const avgOutbound = formatThroughput(latestMetric?.netTxAvg);
+
+  return (
+    <article className="panel">
+      <div className="panel__header">
+        <div>
+          <h2>Security &amp; exposure overview</h2>
+          <p>Snapshot of external reachability and system surface area.</p>
+        </div>
+      </div>
+      <div className="panel__table-wrapper">
+        <table className="detail-table" aria-label="Security posture metrics">
+          <tbody>
+            <tr>
+              <th scope="row">Listening sockets</th>
+              <td>{tcpListeners} TCP • {udpListeners} UDP</td>
+            </tr>
+            <tr>
+              <th scope="row">Active remote domains</th>
+              <td>{uniqueDomains}</td>
+            </tr>
+            <tr>
+              <th scope="row">Average network throughput (30s)</th>
+              <td>↓{avgInbound} • ↑{avgOutbound}</td>
+            </tr>
+            <tr>
+              <th scope="row">Open file descriptors</th>
+              <td>{openFds}</td>
+            </tr>
+            <tr>
+              <th scope="row">Running processes</th>
+              <td>{processes}</td>
+            </tr>
+            <tr>
+              <th scope="row">Total threads</th>
+              <td>{threads}</td>
+            </tr>
+            <tr>
+              <th scope="row">Active connections</th>
+              <td>{formatConnections(latestMetric?.connections)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </article>
+  );
+}
+
+export default SecurityOverview;

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,5 +1,5 @@
 const rawMaxPoints = Number(process.env.REACT_APP_MAX_POINTS || 180);
-const rawSampleInterval = Number(process.env.REACT_APP_SAMPLE_INTERVAL_SECONDS || 1);
+const rawSampleInterval = Number(process.env.REACT_APP_SAMPLE_INTERVAL_SECONDS || 0.5);
 const rawRetentionDays = Number(process.env.REACT_APP_DEFAULT_RETENTION_DAYS || 7);
 
 const sampleIntervalSeconds = Number.isFinite(rawSampleInterval) && rawSampleInterval > 0 ? rawSampleInterval : 1;

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -17,6 +17,13 @@ export const formatConnections = (value) => {
   return Number(value).toLocaleString();
 };
 
+export const formatCount = (value) => {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) {
+    return '--';
+  }
+  return Number(value).toLocaleString();
+};
+
 export const formatLoad = (value) => {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) {
@@ -79,6 +86,13 @@ export const formatMegabytes = (value) => {
     return `${(numeric / 1024).toFixed(2)} GB`;
   }
   return `${numeric.toFixed(1)} MB`;
+};
+
+export const formatBoolean = (value) => {
+  if (value === null || value === undefined) {
+    return '--';
+  }
+  return value ? 'Yes' : 'No';
 };
 
 const normaliseDate = (value) => {

--- a/frontend/src/utils/payload.js
+++ b/frontend/src/utils/payload.js
@@ -33,6 +33,32 @@ const normaliseDomains = (rawDomains) => {
     .filter((item) => item.domain);
 };
 
+const normaliseDockerContainers = (rawContainers) => {
+  if (!Array.isArray(rawContainers)) {
+    return [];
+  }
+
+  return rawContainers.map((container) => ({
+    id: String(container?.id ?? container?.containerId ?? ''),
+    name: String(container?.name ?? container?.Names ?? container?.container ?? '').trim(),
+    image: String(container?.image ?? container?.Image ?? '').trim(),
+    status: String(container?.status ?? container?.State ?? container?.Status ?? '').trim()
+  }));
+};
+
+const normaliseDockerImages = (rawImages) => {
+  if (!Array.isArray(rawImages)) {
+    return [];
+  }
+
+  return rawImages.map((image) => ({
+    repository: String(image?.repository ?? image?.repo ?? image?.Repository ?? '').trim(),
+    tag: String(image?.tag ?? image?.Tag ?? '').trim(),
+    id: String(image?.id ?? image?.imageId ?? image?.ID ?? '').trim(),
+    size: String(image?.size ?? image?.Size ?? '').trim()
+  }));
+};
+
 export const normaliseMetricPayload = (payload) => {
   const timestampIso = payload.timestamp || payload.time || new Date().toISOString();
   let sampleDate = new Date(timestampIso);
@@ -42,7 +68,9 @@ export const normaliseMetricPayload = (payload) => {
 
   return {
     cpu: Number(payload.cpu ?? payload.cpuUsage ?? 0),
+    cpuAvg: Number(payload.cpuAvg ?? payload.cpuAverage ?? payload.cpuUsageAverage ?? 0),
     memory: Number(payload.memory ?? payload.memoryUsage ?? 0),
+    swap: Number(payload.swap ?? payload.swapUsage ?? 0),
     connections: Number(payload.connections ?? payload.activeConnections ?? 0),
     disk: Number(payload.disk ?? payload.diskUsage ?? 0),
     load1: Number(payload.load1 ?? payload.loadAverage1 ?? 0),
@@ -50,7 +78,18 @@ export const normaliseMetricPayload = (payload) => {
     load15: Number(payload.load15 ?? payload.loadAverage15 ?? 0),
     netRx: Number(payload.netRx ?? payload.networkReceiveRate ?? 0),
     netTx: Number(payload.netTx ?? payload.networkTransmitRate ?? 0),
+    netRxAvg: Number(payload.netRxAvg ?? payload.networkReceiveRateAverage ?? 0),
+    netTxAvg: Number(payload.netTxAvg ?? payload.networkTransmitRateAverage ?? 0),
     cpuCores: Number(payload.cpuCores ?? payload.cpuCount ?? 0),
+    processes: Number(payload.processes ?? payload.processCount ?? 0),
+    threads: Number(payload.threads ?? payload.threadCount ?? 0),
+    listeningTcp: Number(payload.listeningTcp ?? payload.tcpListening ?? 0),
+    listeningUdp: Number(payload.listeningUdp ?? payload.udpListening ?? 0),
+    openFds: Number(payload.openFds ?? payload.openFileDescriptors ?? 0),
+    uniqueDomains: Number(payload.uniqueDomains ?? payload.domainCount ?? 0),
+    dockerAvailable: Boolean(payload.dockerAvailable ?? payload.docker ?? false),
+    dockerContainers: normaliseDockerContainers(payload.dockerContainers ?? payload.containers),
+    dockerImages: normaliseDockerImages(payload.dockerImages ?? payload.images),
     applications: normaliseApplications(payload.applications ?? payload.topApplications),
     domains: normaliseDomains(payload.domains ?? payload.domainUsage),
     time: sampleDate.toLocaleTimeString([], {

--- a/frontend/src/utils/statistics.js
+++ b/frontend/src/utils/statistics.js
@@ -7,7 +7,17 @@ const metricsToSummarise = [
   'load5',
   'load15',
   'netRx',
-  'netTx'
+  'netTx',
+  'cpuAvg',
+  'swap',
+  'netRxAvg',
+  'netTxAvg',
+  'processes',
+  'threads',
+  'listeningTcp',
+  'listeningUdp',
+  'openFds',
+  'uniqueDomains'
 ];
 
 const summariseValues = (values) => {


### PR DESCRIPTION
## Summary
- extend the backend metrics collector with rolling averages, swap usage, process/thread counts, socket exposure, DNS resolution, and Docker inventory data while smoothing WebSocket sampling
- expose the richer metric payloads via the WebSocket and REST APIs and harden the WebSocket session against broken pipe errors
- update the frontend dashboard with new KPI cards, security overview, and Docker resources panels plus parsing/formatting logic for the additional data

## Testing
- ⚠️ `cmake -S backend -B backend/build` *(fails: Boost development headers are not present in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e3a0502883338642e5f0b23e2eec