### PR TITLE
Fix lambda capture for connection summary parsing

### DIFF
--- a/backend/src/system_metrics.cpp
+++ b/backend/src/system_metrics.cpp
@@ -880,7 +880,7 @@ MetricsCollector::ConnectionSummary MetricsCollector::read_connection_summary()
     ConnectionSummary summary{};
     summary.totalConnections = 0;
 
-    auto parse_tcp_file = [&summary](const std::string &path, bool ipv6) {
+    auto parse_tcp_file = [this, &summary](const std::string &path, bool ipv6) {
         std::ifstream tcp_file(path);
         if (!tcp_file.is_open())
         {


### PR DESCRIPTION
## Summary
- capture the MetricsCollector instance in the connection summary parser so hostname resolution works

## Testing
- cmake -S backend -B backend/build *(fails: missing Boost libraries in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e7f1a03083339c515849cda66d48