### PR TITLE
Add scoped metrics filtering and Docker stats reporting

### DIFF
--- a/backend/src/system_metrics.h
+++ b/backend/src/system_metrics.h
@@ -15,6 +15,7 @@ struct ApplicationUsage
     std::string name;
     double cpuPercent;
     double memoryMb;
+    std::string commandLine;
 };
 
 struct DomainUsage
@@ -31,6 +32,15 @@ struct DockerContainerSummary
     std::string name;
     std::string image;
     std::string status;
+    double cpuPercent;
+    double memoryUsageMb;
+    double memoryLimitMb;
+    double memoryPercent;
+    double networkRxKb;
+    double networkTxKb;
+    double blockReadKb;
+    double blockWriteKb;
+    unsigned int pids;
 };
 
 struct DockerImageSummary


### PR DESCRIPTION
## Summary
- include process command lines in collected metrics and surface full Docker resource data
- parse `docker ps` and `docker stats` output to expose CPU, memory, network, and block IO utilisation per container
- allow clients to pass a `target` query parameter to aggregate metrics for matching processes or containers

## Testing
- `cmake -S Monitoring_System/backend -B Monitoring_System/backend/build` *(fails: missing Boost libraries in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5eaa7c03c8333bf7154e8cecd57a6