### PR TITLE
Add background process filtering to application metrics

### DIFF
--- a/backend/src/websocket_server.cpp
+++ b/backend/src/websocket_server.cpp
@@ -222,7 +222,8 @@ void WebSocketServer::run() {
                                 {"pid", app.pid},
                                 {"name", app.name},
                                 {"cpu", app.cpuPercent},
-                                {"memoryMb", app.memoryMb}
+                                {"memoryMb", app.memoryMb},
+                                {"commandLine", app.commandLine}
                             });
                         }
                         j["domains"] = nlohmann::json::array();

--- a/frontend/src/components/ApplicationUsagePanel.js
+++ b/frontend/src/components/ApplicationUsagePanel.js
@@ -1,9 +1,90 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { formatMegabytes, formatPercentLabel } from '../utils/formatters';
 
+const ACTIVE_CPU_THRESHOLD = 1;
+
+const FILTERS = [
+  {
+    id: 'all',
+    label: 'All processes',
+    predicate: () => true
+  },
+  {
+    id: 'active',
+    label: 'Active',
+    predicate: (app) => app.cpu >= ACTIVE_CPU_THRESHOLD
+  },
+  {
+    id: 'background',
+    label: 'Background',
+    predicate: (app) => app.cpu < ACTIVE_CPU_THRESHOLD
+  }
+];
+
+const getFilterCount = (counts, filterId) => {
+  switch (filterId) {
+    case 'active':
+      return counts.active;
+    case 'background':
+      return counts.background;
+    default:
+      return counts.all;
+  }
+};
+
+const buildFilterMessage = (filterId) => {
+  if (filterId === 'active') {
+    return 'No active processes detected in the latest sample. Waiting for CPU activity spikes.';
+  }
+  if (filterId === 'background') {
+    return `No background processes below ${ACTIVE_CPU_THRESHOLD}% CPU were observed this cycle.`;
+  }
+  return 'No processes matched the current filter.';
+};
+
 function ApplicationUsagePanel({ applications }) {
-  const hasData = Array.isArray(applications) && applications.length > 0;
+  const [activeFilter, setActiveFilter] = useState('all');
+
+  const { filteredApplications, counts, selectedFilter } = useMemo(() => {
+    const fallbackFilter = FILTERS[0];
+    const filter = FILTERS.find((item) => item.id === activeFilter) || fallbackFilter;
+
+    if (!Array.isArray(applications) || applications.length === 0) {
+      return {
+        filteredApplications: [],
+        counts: { all: 0, active: 0, background: 0 },
+        selectedFilter: filter
+      };
+    }
+
+    const totals = { all: applications.length, active: 0, background: 0 };
+    const normalised = applications.map((app) => {
+      const cpu = Number(app?.cpu ?? 0);
+      const memoryMb = Number(app?.memoryMb ?? 0);
+      if (cpu >= ACTIVE_CPU_THRESHOLD) {
+        totals.active += 1;
+      } else {
+        totals.background += 1;
+      }
+
+      return {
+        ...app,
+        cpu,
+        memoryMb,
+        commandLine: typeof app?.commandLine === 'string' ? app.commandLine : ''
+      };
+    });
+
+    return {
+      filteredApplications: normalised.filter((app) => filter.predicate(app)),
+      counts: totals,
+      selectedFilter: filter
+    };
+  }, [applications, activeFilter]);
+
+  const hasData = counts.all > 0;
+  const hasFilteredRows = filteredApplications.length > 0;
 
   return (
     <article className="panel">
@@ -13,32 +94,80 @@ function ApplicationUsagePanel({ applications }) {
           <p>Top processes ranked by CPU saturation with resident memory usage.</p>
         </div>
       </div>
-      {hasData ? (
-        <div className="panel__table-wrapper">
-          <table className="detail-table" aria-label="Top application resource usage">
-            <thead>
-              <tr>
-                <th scope="col">Application</th>
-                <th scope="col">CPU</th>
-                <th scope="col">Memory</th>
-                <th scope="col">PID</th>
-              </tr>
-            </thead>
-            <tbody>
-              {applications.map((app) => (
-                <tr key={`${app.pid}-${app.name}`}>
-                  <th scope="row">
-                    <div className="entity-name">{app.name || `Process ${app.pid}`}</div>
-                    <div className="entity-meta">PID {app.pid}</div>
-                  </th>
-                  <td>{formatPercentLabel(app.cpu)}</td>
-                  <td>{formatMegabytes(app.memoryMb)}</td>
-                  <td>{app.pid}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+      <div className="application-usage__controls">
+        <div className="application-usage__filters" role="group" aria-label="Filter processes by activity">
+          {FILTERS.map((filter) => {
+            const isActive = filter.id === selectedFilter.id;
+            return (
+              <button
+                key={filter.id}
+                type="button"
+                className={`application-usage__filter${isActive ? ' application-usage__filter--active' : ''}`}
+                onClick={() => setActiveFilter(filter.id)}
+                aria-pressed={isActive}
+                disabled={!hasData && filter.id !== 'all'}
+              >
+                {filter.label}
+                <span className="application-usage__filter-count">{getFilterCount(counts, filter.id)}</span>
+              </button>
+            );
+          })}
         </div>
+        {hasData ? (
+          <div className="application-usage__meta" role="status">
+            <span>
+              Showing {filteredApplications.length} of {counts.all} processes
+              {selectedFilter.id !== 'all' ? ` · ${selectedFilter.label}` : ''}
+            </span>
+            <span>
+              Active: {counts.active} · Background: {counts.background}
+            </span>
+          </div>
+        ) : null}
+      </div>
+      {hasData ? (
+        hasFilteredRows ? (
+          <div className="panel__table-wrapper">
+            <table className="detail-table" aria-label="Top application resource usage">
+              <thead>
+                <tr>
+                  <th scope="col">Application</th>
+                  <th scope="col">CPU</th>
+                  <th scope="col">Memory</th>
+                  <th scope="col">PID</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredApplications.map((app) => {
+                  const displayName = app.name || `Process ${app.pid}`;
+                  const commandLine = app.commandLine && app.commandLine !== displayName ? app.commandLine : '';
+                  return (
+                    <tr key={`${app.pid}-${displayName}`}>
+                      <th scope="row">
+                        <div className="entity-name">{displayName}</div>
+                        <div className="entity-meta">
+                          PID {app.pid}
+                          {commandLine ? (
+                            <span className="entity-meta__command" title={app.commandLine}>
+                              {commandLine}
+                            </span>
+                          ) : null}
+                        </div>
+                      </th>
+                      <td>{formatPercentLabel(app.cpu)}</td>
+                      <td>{formatMegabytes(app.memoryMb)}</td>
+                      <td>{app.pid}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="panel__empty" role="status">
+            <p>{buildFilterMessage(selectedFilter.id)}</p>
+          </div>
+        )
       ) : (
         <div className="panel__empty" role="status">
           <p>No processes sampled yet. Waiting for activity.</p>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -661,6 +661,80 @@ a {
   color: var(--text-surface-muted);
 }
 
+.application-usage__controls {
+  margin: 16px 0 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.application-usage__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.application-usage__filter {
+  border: none;
+  border-radius: 999px;
+  padding: 6px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-surface-muted);
+  transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
+}
+
+.application-usage__filter:hover,
+.application-usage__filter:focus {
+  background: rgba(99, 102, 241, 0.16);
+  transform: translateY(-1px);
+  color: var(--text-surface);
+}
+
+.application-usage__filter:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.application-usage__filter--active,
+.application-usage__filter--active:hover,
+.application-usage__filter--active:focus {
+  background: rgba(99, 102, 241, 0.22);
+  color: var(--text-surface);
+}
+
+.application-usage__filter-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: rgba(148, 163, 184, 0.25);
+  color: var(--text-surface-muted);
+}
+
+.application-usage__filter--active .application-usage__filter-count {
+  background: rgba(99, 102, 241, 0.3);
+  color: var(--text-surface);
+}
+
+.application-usage__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: var(--text-surface-muted);
+}
+
 .detail-table {
   width: 100%;
   border-collapse: collapse;
@@ -697,6 +771,15 @@ a {
   margin-top: 4px;
   font-size: 0.8rem;
   color: var(--text-surface-muted);
+}
+
+.entity-meta__command {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.75rem;
+  color: var(--text-surface-muted);
+  word-break: break-word;
+  white-space: normal;
 }
 
 .panel__empty {

--- a/frontend/src/utils/payload.js
+++ b/frontend/src/utils/payload.js
@@ -8,11 +8,13 @@ const normaliseApplications = (rawApplications) => {
       const pid = Number(app?.pid ?? app?.processId ?? app?.id);
       const cpu = Number(app?.cpu ?? app?.cpuPercent ?? app?.cpuUsage ?? 0);
       const memoryMb = Number(app?.memoryMb ?? app?.memory ?? app?.memoryUsage ?? 0);
+      const commandLine = String(app?.commandLine ?? app?.cmd ?? app?.command ?? '').trim();
       return {
         pid: Number.isFinite(pid) ? pid : 0,
         name: String(app?.name ?? app?.process ?? `PID ${pid}`),
         cpu,
-        memoryMb
+        memoryMb,
+        commandLine
       };
     })
     .filter((app) => app.name);


### PR DESCRIPTION
## Summary
- include command line details in websocket application payloads for the dashboard
- add filter controls so the application usage panel can focus on background or active processes
- style the new controls and surface process command lines in the UI table

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5ecb80cb4833392952d364a539e58