### PR TITLE
Add dashboard navigation and interactive metric details

### DIFF
--- a/backend/src/system_metrics.cpp
+++ b/backend/src/system_metrics.cpp
@@ -764,7 +764,17 @@ std::pair<std::vector<DockerContainerSummary>, std::vector<DockerImageSummary>> 
     std::vector<DockerImageSummary> images;
 
     auto run_command = [](const char *cmd, std::vector<std::string> &lines) -> bool {
-        FILE *pipe = popen(cmd, "r");
+        if (cmd == nullptr)
+        {
+            return false;
+        }
+
+        std::string command(cmd);
+#ifndef _WIN32
+        command.append(" 2>/dev/null");
+#endif
+
+        FILE *pipe = popen(command.c_str(), "r");
         if (pipe == nullptr)
         {
             return false;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import AppHeader from './components/AppHeader';
 import ApplicationUsagePanel from './components/ApplicationUsagePanel';
@@ -6,6 +6,7 @@ import ConnectionsChart from './components/ConnectionsChart';
 import HistoryPanel from './components/HistoryPanel';
 import KpiGrid from './components/KpiGrid';
 import MetricChart from './components/MetricChart';
+import MetricDetailsPanel from './components/MetricDetailsPanel';
 import PerformanceSummary from './components/PerformanceSummary';
 import SettingsPanel from './components/SettingsPanel';
 import StatusTimeline from './components/StatusTimeline';
@@ -17,11 +18,32 @@ import DomainTrafficPanel from './components/DomainTrafficPanel';
 import SecurityOverview from './components/SecurityOverview';
 import DockerResourcesPanel from './components/DockerResourcesPanel';
 import OptimizationInsightsPanel from './components/OptimizationInsightsPanel';
+import { buildMetricDetailsMap } from './utils/metricDetails';
+
+const NAVIGATION = [
+  {
+    id: 'overview',
+    label: 'Overview',
+    description: 'Health, saturation, and stability'
+  },
+  {
+    id: 'network',
+    label: 'Network',
+    description: 'Connections and traffic intelligence'
+  },
+  {
+    id: 'operations',
+    label: 'Operations',
+    description: 'Processes, security, and containers'
+  }
+];
 
 function App() {
   const { retentionSeconds, retentionDays, updateSetting } = useSettings();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [activePage, setActivePage] = useState('overview');
+  const [selectedMetricId, setSelectedMetricId] = useState(null);
   const {
     metrics,
     latestMetric,
@@ -32,6 +54,18 @@ function App() {
   } = useLiveMetrics({ retentionSeconds });
 
   const stats = useMemo(() => buildStatistics(metrics), [metrics]);
+  const metricDetails = useMemo(
+    () => buildMetricDetailsMap({ latestMetric, previousMetric, stats }),
+    [latestMetric, previousMetric, stats]
+  );
+  const selectedMetric = selectedMetricId ? metricDetails[selectedMetricId] : null;
+
+  useEffect(() => {
+    if (selectedMetricId && !metricDetails[selectedMetricId]) {
+      setSelectedMetricId(null);
+    }
+  }, [metricDetails, selectedMetricId]);
+
   const { snapshots, saveSnapshot, deleteSnapshot, clearSnapshots, exportSnapshot } = useMetricsHistory({
     metrics,
     latestMetric,
@@ -43,6 +77,17 @@ function App() {
     if (saved) {
       setHistoryOpen(true);
     }
+  };
+
+  const handleMetricSelect = (metricId) => {
+    if (!metricId || !metricDetails[metricId]) {
+      return;
+    }
+    setSelectedMetricId(metricId);
+  };
+
+  const handleCloseDetails = () => {
+    setSelectedMetricId(null);
   };
 
   return (
@@ -59,71 +104,123 @@ function App() {
       />
 
       <main className="app-main">
-        <KpiGrid
-          latestMetric={latestMetric}
-          previousMetric={previousMetric}
-          stats={stats}
-          health={health}
-        />
+        <nav className="app-nav" aria-label="Dashboard navigation">
+          {NAVIGATION.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={`app-nav__item ${activePage === item.id ? 'app-nav__item--active' : ''}`}
+              onClick={() => setActivePage(item.id)}
+            >
+              <span className="app-nav__label">{item.label}</span>
+              <span className="app-nav__description">{item.description}</span>
+            </button>
+          ))}
+        </nav>
 
-        <section className="panel-grid" aria-label="Charts">
-          <article className="panel panel--primary">
-            <div className="panel__header">
-              <div>
-                <h2>Resource utilisation</h2>
-                <p>CPU and memory saturation sampled each second.</p>
-              </div>
-              <span className="panel__tag">Live</span>
-            </div>
-            <MetricChart data={metrics} />
-          </article>
+        <div className="app-page" role="tabpanel">
+          {activePage === 'overview' && (
+            <>
+              <KpiGrid
+                latestMetric={latestMetric}
+                previousMetric={previousMetric}
+                stats={stats}
+                health={health}
+                onSelectMetric={handleMetricSelect}
+              />
 
-          <article className="panel">
-            <div className="panel__header">
-              <div>
-                <h2>Connection load</h2>
-                <p>Client connections observed over time.</p>
-              </div>
-            </div>
-            <ConnectionsChart data={metrics} />
-          </article>
-        </section>
+              <section className="panel-grid panel-grid--single" aria-label="Resource utilisation">
+                <article className="panel panel--primary">
+                  <div className="panel__header">
+                    <div>
+                      <h2>Resource utilisation</h2>
+                      <p>CPU and memory saturation sampled each second.</p>
+                    </div>
+                    <span className="panel__tag">Live</span>
+                  </div>
+                  <MetricChart data={metrics} />
+                </article>
+              </section>
 
-        <section className="panel-grid panel-grid--balanced" aria-label="Operational insights">
-          <article className="panel">
-            <div className="panel__header">
-              <div>
-                <h2>Health timeline</h2>
-                <p>Key state changes recorded during this session.</p>
-              </div>
-            </div>
-            <StatusTimeline events={statusEvents} />
-          </article>
+              <section className="panel-grid panel-grid--balanced" aria-label="Operational state">
+                <article className="panel">
+                  <div className="panel__header">
+                    <div>
+                      <h2>Health timeline</h2>
+                      <p>Key state changes recorded during this session.</p>
+                    </div>
+                  </div>
+                  <StatusTimeline events={statusEvents} />
+                </article>
 
-          <PerformanceSummary latestMetric={latestMetric} stats={stats} />
-        </section>
+                <PerformanceSummary latestMetric={latestMetric} stats={stats} />
+              </section>
+            </>
+          )}
 
-        <section className="panel-grid panel-grid--balanced" aria-label="Process and network analytics">
-          <ApplicationUsagePanel applications={latestMetric?.applications ?? []} />
-          <DomainTrafficPanel
-            domains={latestMetric?.domains ?? []}
-            totalConnections={latestMetric?.connections}
-            throughput={{ inbound: latestMetric?.netRx, outbound: latestMetric?.netTx }}
-          />
-        </section>
+          {activePage === 'network' && (
+            <>
+              <section className="panel-grid panel-grid--single" aria-label="Connection analytics">
+                <article className="panel">
+                  <div className="panel__header">
+                    <div>
+                      <h2>Connection load</h2>
+                      <p>Client connections observed over time.</p>
+                    </div>
+                  </div>
+                  <ConnectionsChart data={metrics} />
+                </article>
+              </section>
 
-        <section
-          className="panel-grid panel-grid--balanced"
-          aria-label="Security, containers, and optimisation guidance"
-        >
-          <SecurityOverview latestMetric={latestMetric} />
-          <DockerResourcesPanel
-            dockerAvailable={latestMetric?.dockerAvailable}
-            containers={latestMetric?.dockerContainers ?? []}
-            images={latestMetric?.dockerImages ?? []}
-          />
-          <OptimizationInsightsPanel latestMetric={latestMetric} stats={stats} />
-        </section>
+              <section className="panel-grid panel-grid--balanced" aria-label="Traffic insights">
+                <DomainTrafficPanel
+                  domains={latestMetric?.domains ?? []}
+                  totalConnections={latestMetric?.connections}
+                  throughput={{ inbound: latestMetric?.netRx, outbound: latestMetric?.netTx }}
+                />
+
+                <article className="panel">
+                  <div className="panel__header">
+                    <div>
+                      <h2>Snapshot history</h2>
+                      <p>Capture session state for later comparison.</p>
+                    </div>
+                    <button
+                      type="button"
+                      className="panel__action"
+                      onClick={handleSaveSnapshot}
+                      disabled={!metrics.length}
+                    >
+                      Save snapshot
+                    </button>
+                  </div>
+                  <p className="panel__body-text">
+                    Use the header actions to browse or export previously saved states. Snapshots capture the values feeding this
+                    network view, allowing you to compare trends over time.
+                  </p>
+                </article>
+              </section>
+            </>
+          )}
+
+          {activePage === 'operations' && (
+            <>
+              <section className="panel-grid panel-grid--balanced" aria-label="Workload focus">
+                <ApplicationUsagePanel applications={latestMetric?.applications ?? []} />
+                <OptimizationInsightsPanel latestMetric={latestMetric} stats={stats} />
+              </section>
+
+              <section className="panel-grid panel-grid--balanced" aria-label="Security and containers">
+                <SecurityOverview latestMetric={latestMetric} />
+                <DockerResourcesPanel
+                  dockerAvailable={latestMetric?.dockerAvailable}
+                  containers={latestMetric?.dockerContainers ?? []}
+                  images={latestMetric?.dockerImages ?? []}
+                />
+              </section>
+            </>
+          )}
+        </div>
       </main>
 
       <footer className="app-footer">
@@ -145,9 +242,10 @@ function App() {
         onClearSnapshots={clearSnapshots}
         onExportSnapshot={exportSnapshot}
       />
+
+      <MetricDetailsPanel metric={selectedMetric} onClose={handleCloseDetails} />
     </div>
   );
 }
 
 export default App;
-

--- a/frontend/src/components/KpiGrid.js
+++ b/frontend/src/components/KpiGrid.js
@@ -10,7 +10,7 @@ import {
 } from '../utils/formatters';
 import { buildTrend } from '../utils/trends';
 
-function KpiGrid({ latestMetric, previousMetric, stats, health }) {
+function KpiGrid({ latestMetric, previousMetric, stats, health, onSelectMetric }) {
   return (
     <section className="kpi-grid" aria-label="Key metrics">
       <MetricCard
@@ -24,6 +24,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
             ? `Avg ${formatPercent(stats.cpu.avg)}% • Peak ${formatPercent(stats.cpu.peak)}%`
             : 'Waiting for samples'
         }
+        onSelect={() => onSelectMetric?.('cpu')}
       />
       <MetricCard
         title="Memory usage"
@@ -36,6 +37,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
             ? `Avg ${formatPercent(stats.memory.avg)}% • Peak ${formatPercent(stats.memory.peak)}%`
             : 'Waiting for samples'
         }
+        onSelect={() => onSelectMetric?.('memory')}
       />
       <MetricCard
         title="Disk usage"
@@ -48,6 +50,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
             ? `Avg ${formatPercent(stats.disk.avg)}% • Peak ${formatPercent(stats.disk.peak)}%`
             : 'Waiting for samples'
         }
+        onSelect={() => onSelectMetric?.('disk')}
       />
       <MetricCard
         title="Active connections"
@@ -62,6 +65,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
               ).toLocaleString()}`
             : 'Waiting for samples'
         }
+        onSelect={() => onSelectMetric?.('connections')}
       />
       <MetricCard
         title="Network throughput"
@@ -74,6 +78,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
             ? `Avg ↓${formatThroughput(stats.netRx.avg)} • ↑${formatThroughput(stats.netTx.avg)}`
             : 'Waiting for samples'
         }
+        onSelect={() => onSelectMetric?.('throughput')}
       />
       <MetricCard
         title="CPU avg (60s)"
@@ -86,6 +91,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
             ? `Session avg ${formatPercent(stats.cpuAvg.avg)}%`
             : 'Waiting for samples'
         }
+        onSelect={() => onSelectMetric?.('cpuAvg')}
       />
       <MetricCard
         title="Swap usage"
@@ -98,6 +104,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
             ? `Avg ${formatPercent(stats.swap.avg)}% • Peak ${formatPercent(stats.swap.peak)}%`
             : 'Waiting for samples'
         }
+        onSelect={() => onSelectMetric?.('swap')}
       />
       <MetricCard
         title="Processes"
@@ -110,6 +117,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
             ? `Avg ${formatCount(Math.round(stats.processes.avg))} • Peak ${formatCount(Math.round(stats.processes.peak))}`
             : 'Waiting for samples'
         }
+        onSelect={() => onSelectMetric?.('processes')}
       />
       <MetricCard
         title="Threads"
@@ -122,6 +130,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
             ? `Avg ${formatCount(Math.round(stats.threads.avg))} • Peak ${formatCount(Math.round(stats.threads.peak))}`
             : 'Waiting for samples'
         }
+        onSelect={() => onSelectMetric?.('threads')}
       />
       <MetricCard
         title="Listening sockets"
@@ -134,6 +143,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
             ? `Avg TCP ${formatCount(Math.round(stats.listeningTcp.avg))} • UDP ${formatCount(Math.round(stats.listeningUdp.avg))}`
             : 'Waiting for samples'
         }
+        onSelect={() => onSelectMetric?.('listeningSockets')}
       />
       <MetricCard
         title="Unique domains"
@@ -146,6 +156,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
             ? `Avg ${formatCount(Math.round(stats.uniqueDomains.avg))} • Peak ${formatCount(Math.round(stats.uniqueDomains.peak))}`
             : 'Waiting for samples'
         }
+        onSelect={() => onSelectMetric?.('uniqueDomains')}
       />
       <MetricCard
         title="Docker containers"
@@ -158,6 +169,7 @@ function KpiGrid({ latestMetric, previousMetric, stats, health }) {
             ? `${formatCount(latestMetric?.dockerImages?.length ?? 0)} images discovered`
             : 'Docker CLI unavailable'
         }
+        onSelect={() => onSelectMetric?.('docker')}
       />
     </section>
   );

--- a/frontend/src/components/MetricCard.js
+++ b/frontend/src/components/MetricCard.js
@@ -12,14 +12,32 @@ const trendLabel = {
   steady: 'Stable'
 };
 
-function MetricCard({ title, value, unit, helper, trend, status }) {
+function MetricCard({ title, value, unit, helper, trend, status, onSelect }) {
   const hasUnit = unit && unit.trim().length > 0;
   const visualStatus = status ? `metric-card--${status}` : 'metric-card--neutral';
   const formattedValue = value === null || value === undefined ? '--' : value;
   const showUnit = hasUnit && formattedValue !== '--';
+  const interactive = typeof onSelect === 'function';
+
+  const handleKeyDown = (event) => {
+    if (!interactive) {
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelect();
+    }
+  };
 
   return (
-    <article className={`metric-card ${visualStatus}`}>
+    <article
+      className={`metric-card ${visualStatus} ${interactive ? 'metric-card--interactive' : ''}`}
+      onClick={interactive ? onSelect : undefined}
+      onKeyDown={handleKeyDown}
+      role={interactive ? 'button' : undefined}
+      tabIndex={interactive ? 0 : undefined}
+    >
       <header className="metric-card__header">
         <p className="metric-card__title">{title}</p>
       </header>
@@ -40,6 +58,7 @@ function MetricCard({ title, value, unit, helper, trend, status }) {
           {trend.label}
         </p>
       )}
+      {interactive && <span className="metric-card__action">View details</span>}
     </article>
   );
 }

--- a/frontend/src/components/MetricDetailsPanel.js
+++ b/frontend/src/components/MetricDetailsPanel.js
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+
+function MetricDetailsPanel({ metric, onClose }) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [metric?.id]);
+
+  if (!metric) {
+    return null;
+  }
+
+  const { title, headline, summary = [], description, items = [] } = metric;
+  const activeItem = items.length ? items[Math.min(activeIndex, items.length - 1)] : null;
+
+  const handleNext = () => {
+    if (items.length < 2) {
+      return;
+    }
+    setActiveIndex((index) => (index + 1) % items.length);
+  };
+
+  const handlePrev = () => {
+    if (items.length < 2) {
+      return;
+    }
+    setActiveIndex((index) => (index - 1 + items.length) % items.length);
+  };
+
+  return (
+    <aside className="metric-details" aria-live="polite">
+      <header className="metric-details__header">
+        <div>
+          <p className="metric-details__eyebrow">Metric spotlight</p>
+          <h2>{title}</h2>
+          {headline && <p className="metric-details__headline">{headline}</p>}
+        </div>
+        <button type="button" className="metric-details__close" onClick={onClose} aria-label="Close metric details">
+          ×
+        </button>
+      </header>
+
+      {description && <p className="metric-details__description">{description}</p>}
+
+      {summary.length > 0 && (
+        <dl className="metric-details__summary">
+          {summary.map((item) => (
+            <div key={item.label} className="metric-details__summary-item">
+              <dt>{item.label}</dt>
+              <dd>
+                <span>{item.value}</span>
+                {item.description && <small>{item.description}</small>}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      {items.length > 0 && (
+        <section className="metric-details__items" aria-label="Metric entries">
+          <header className="metric-details__items-header">
+            <h3>Entries</h3>
+            <span>{items.length} item{items.length === 1 ? '' : 's'}</span>
+          </header>
+          <div className="metric-details__carousel">
+            <button
+              type="button"
+              className="metric-details__nav"
+              onClick={handlePrev}
+              disabled={items.length < 2}
+              aria-label="Previous entry"
+            >
+              ‹
+            </button>
+            <div className="metric-details__item">
+              {activeItem ? (
+                <>
+                  <h4>{activeItem.title}</h4>
+                  {activeItem.subtitle && <p className="metric-details__item-subtitle">{activeItem.subtitle}</p>}
+                  {activeItem.description && <p className="metric-details__item-description">{activeItem.description}</p>}
+                </>
+              ) : (
+                <p className="metric-details__item-empty">Waiting for live samples…</p>
+              )}
+            </div>
+            <button
+              type="button"
+              className="metric-details__nav"
+              onClick={handleNext}
+              disabled={items.length < 2}
+              aria-label="Next entry"
+            >
+              ›
+            </button>
+          </div>
+          {items.length > 1 && (
+            <div className="metric-details__dots" role="tablist" aria-label="Select metric entry">
+              {items.map((item, index) => (
+                <button
+                  key={item.id || item.title || index}
+                  type="button"
+                  className={`metric-details__dot ${index === activeIndex ? 'metric-details__dot--active' : ''}`}
+                  onClick={() => setActiveIndex(index)}
+                  aria-label={`View entry ${index + 1}: ${item.title || item.id || 'item'}`}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+    </aside>
+  );
+}
+
+export default MetricDetailsPanel;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -203,6 +203,66 @@ a {
   gap: 24px;
 }
 
+.app-nav {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  background: rgba(255, 255, 255, 0.12);
+  padding: 12px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow-card);
+  position: sticky;
+  top: 16px;
+  z-index: 5;
+}
+
+.app-nav__item {
+  flex: 1 1 160px;
+  min-width: 160px;
+  border: none;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text-primary);
+  padding: 12px 16px;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-nav__item:hover,
+.app-nav__item:focus {
+  transform: translateY(-2px);
+  background: rgba(15, 23, 42, 0.16);
+  outline: none;
+}
+
+.app-nav__item--active {
+  background: rgba(37, 99, 235, 0.35);
+  box-shadow: 0 18px 35px -25px rgba(37, 99, 235, 0.75);
+}
+
+.app-nav__label {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.app-nav__description {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.app-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding-bottom: 140px;
+}
+
 .kpi-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -306,6 +366,35 @@ a {
   box-shadow: var(--shadow-card);
 }
 
+.metric-card--interactive {
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.metric-card--interactive:hover,
+.metric-card--interactive:focus,
+.metric-card--interactive:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 30px 60px -40px rgba(37, 99, 235, 0.65);
+  outline: none;
+}
+
+.metric-card__action {
+  margin-top: auto;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1d4ed8;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.metric-card__action::after {
+  content: '›';
+  font-size: 1rem;
+  transform: translateY(-1px);
+}
+
 .panel-grid {
   display: grid;
   grid-template-columns: 2fr 1fr;
@@ -314,6 +403,10 @@ a {
 
 .panel-grid--balanced {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.panel-grid--single {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .panel {
@@ -353,6 +446,29 @@ a {
   gap: 16px;
 }
 
+.panel__action {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.panel__action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.panel__action:not(:disabled):hover,
+.panel__action:not(:disabled):focus {
+  background: rgba(37, 99, 235, 0.22);
+  transform: translateY(-1px);
+  outline: none;
+}
+
 .panel__header h2 {
   font-size: 1.2rem;
   color: var(--text-surface);
@@ -362,6 +478,12 @@ a {
   margin-top: 4px;
   font-size: 0.95rem;
   color: var(--text-surface-muted);
+}
+
+.panel__body-text {
+  margin: 0;
+  color: var(--text-surface-muted);
+  line-height: 1.7;
 }
 
 .panel__tag {
@@ -1180,6 +1302,16 @@ a {
   .panel-grid {
     grid-template-columns: 1fr;
   }
+
+  .app-nav {
+    position: static;
+  }
+
+  .metric-details {
+    right: 24px;
+    bottom: 24px;
+    width: min(420px, calc(100% - 32px));
+  }
 }
 
 @media (max-width: 768px) {
@@ -1206,6 +1338,22 @@ a {
   .history-panel__surface {
     inset: 24px;
   }
+
+  .app-nav {
+    overflow-x: auto;
+    gap: 8px;
+  }
+
+  .app-nav__item {
+    flex: 1 0 200px;
+  }
+
+  .metric-details {
+    left: 16px;
+    right: 16px;
+    bottom: 16px;
+    width: auto;
+  }
 }
 
 @media (max-width: 540px) {
@@ -1226,4 +1374,188 @@ a {
   .history-panel__surface {
     inset: 16px;
   }
+
+  .app-page {
+    padding-bottom: 200px;
+  }
+
+  .metric-details {
+    bottom: 12px;
+    padding: 20px;
+  }
+}
+
+.metric-details {
+  position: fixed;
+  right: 32px;
+  bottom: 32px;
+  width: min(420px, calc(100% - 48px));
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-soft);
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: 0 32px 70px -40px rgba(15, 23, 42, 0.55);
+  color: var(--text-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  z-index: 15;
+  backdrop-filter: blur(16px);
+}
+
+.metric-details__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.metric-details__eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: rgba(15, 23, 42, 0.6);
+  margin: 0 0 6px;
+}
+
+.metric-details__headline {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-surface-muted);
+  margin-top: 6px;
+}
+
+.metric-details__close {
+  background: rgba(15, 23, 42, 0.08);
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: var(--text-surface);
+}
+
+.metric-details__description {
+  margin: 0;
+  color: var(--text-surface-muted);
+  line-height: 1.6;
+}
+
+.metric-details__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.metric-details__summary-item {
+  background: rgba(15, 23, 42, 0.06);
+  border-radius: 16px;
+  padding: 12px 14px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.metric-details__summary-item dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(15, 23, 42, 0.6);
+  margin-bottom: 6px;
+}
+
+.metric-details__summary-item dd {
+  margin: 0;
+  color: var(--text-surface);
+  font-size: 0.95rem;
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.metric-details__summary-item dd small {
+  font-weight: 400;
+  color: var(--text-surface-muted);
+}
+
+.metric-details__items {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.metric-details__items-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  color: var(--text-surface-muted);
+}
+
+.metric-details__carousel {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: stretch;
+  gap: 12px;
+}
+
+.metric-details__nav {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.18);
+  background: rgba(15, 23, 42, 0.06);
+  cursor: pointer;
+  font-size: 1.4rem;
+  color: var(--text-surface);
+}
+
+.metric-details__nav:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.metric-details__item {
+  background: rgba(255, 255, 255, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 18px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.metric-details__item-subtitle {
+  margin: 0;
+  color: var(--text-surface-muted);
+}
+
+.metric-details__item-description {
+  margin: 0;
+  color: var(--text-surface-muted);
+  line-height: 1.6;
+}
+
+.metric-details__item-empty {
+  margin: 0;
+  color: var(--text-surface-muted);
+}
+
+.metric-details__dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.metric-details__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(148, 163, 184, 0.4);
+  cursor: pointer;
+}
+
+.metric-details__dot--active {
+  background: rgba(37, 99, 235, 0.9);
 }

--- a/frontend/src/utils/metricDetails.js
+++ b/frontend/src/utils/metricDetails.js
@@ -1,0 +1,231 @@
+import {
+  formatBoolean,
+  formatConnections,
+  formatCount,
+  formatCpuCores,
+  formatLoad,
+  formatLoadPerCore,
+  formatMegabytes,
+  formatPercent,
+  formatThroughput,
+  formatThroughputPair
+} from './formatters';
+
+const buildSummaryItem = (label, value, description) => ({
+  label,
+  value,
+  description
+});
+
+const buildDomainItems = (domains = []) =>
+  domains.map((domain) => ({
+    id: domain.domain,
+    title: domain.domain,
+    subtitle: `${formatConnections(domain.connections)} active connections`,
+    description: `Inbound ${formatThroughput(domain.receiveRate)} • Outbound ${formatThroughput(domain.transmitRate)}`
+  }));
+
+const buildApplicationItems = (applications = []) =>
+  applications.map((app) => ({
+    id: String(app.pid),
+    title: `${app.name}`,
+    subtitle: `PID ${formatCount(app.pid)} • CPU ${formatPercent(app.cpu)}%`,
+    description: `Memory ${formatMegabytes(app.memoryMb)}${app.commandLine ? ` • ${app.commandLine}` : ''}`
+  }));
+
+const buildDockerContainerItems = (containers = []) =>
+  containers.map((container) => ({
+    id: container.id || container.name,
+    title: container.name || container.id,
+    subtitle: `${container.image || 'unknown image'} • ${container.status || 'status unavailable'}`,
+    description: [
+      container.cpuPercent !== undefined && container.cpuPercent !== null
+        ? `CPU ${formatPercent(container.cpuPercent)}%`
+        : null,
+      container.memoryUsageMb !== undefined && container.memoryUsageMb !== null
+        ? `Memory ${formatMegabytes(container.memoryUsageMb)}`
+        : null,
+      container.networkRxKb !== undefined && container.networkTxKb !== undefined
+        ? `Network ${formatThroughput(container.networkRxKb)} in / ${formatThroughput(container.networkTxKb)} out`
+        : null
+    ]
+      .filter(Boolean)
+      .join(' • ')
+  }));
+
+const buildDockerImageItems = (images = []) =>
+  images.map((image) => ({
+    id: image.id,
+    title: image.repository || 'repository unknown',
+    subtitle: `${image.tag || 'latest'} • ${image.id || 'image id unavailable'}`,
+    description: image.size ? `Size ${image.size}` : 'Size unavailable'
+  }));
+
+export const buildMetricDetailsMap = ({ latestMetric, previousMetric, stats }) => {
+  if (!latestMetric) {
+    return {};
+  }
+
+  const detailMap = {
+    cpu: {
+      id: 'cpu',
+      title: 'CPU utilisation',
+      headline: `${formatPercent(latestMetric.cpu)}%`,
+      summary: [
+        buildSummaryItem('Current utilisation', `${formatPercent(latestMetric.cpu)}%`),
+        buildSummaryItem(
+          'Average (session)',
+          `${formatPercent(stats?.cpu?.avg)}%`,
+          'Rolling average computed across the active monitoring session.'
+        ),
+        buildSummaryItem('Load average (1m)', formatLoad(latestMetric.load1)),
+        buildSummaryItem(
+          'Load per core',
+          formatLoadPerCore(latestMetric.load1, latestMetric.cpuCores),
+          `Detected ${formatCpuCores(latestMetric.cpuCores)} CPU cores.`
+        )
+      ]
+    },
+    memory: {
+      id: 'memory',
+      title: 'Memory usage',
+      headline: `${formatPercent(latestMetric.memory)}%`,
+      summary: [
+        buildSummaryItem('Physical memory in use', `${formatPercent(latestMetric.memory)}%`),
+        buildSummaryItem('Swap usage', `${formatPercent(latestMetric.swap)}%`),
+        buildSummaryItem('Processes tracked', formatCount(latestMetric.processes)),
+        buildSummaryItem('Threads tracked', formatCount(latestMetric.threads))
+      ],
+      items: buildApplicationItems(latestMetric.applications)
+    },
+    disk: {
+      id: 'disk',
+      title: 'Disk usage',
+      headline: `${formatPercent(latestMetric.disk)}%`,
+      summary: [
+        buildSummaryItem('Current utilisation', `${formatPercent(latestMetric.disk)}%`),
+        buildSummaryItem(
+          'Peak utilisation',
+          `${formatPercent(stats?.disk?.peak)}%`,
+          'Highest disk saturation recorded during the session.'
+        ),
+        buildSummaryItem('Open file descriptors', formatCount(latestMetric.openFds))
+      ]
+    },
+    connections: {
+      id: 'connections',
+      title: 'Active connections',
+      headline: formatConnections(latestMetric.connections),
+      summary: [
+        buildSummaryItem('Active TCP connections', formatConnections(latestMetric.connections)),
+        buildSummaryItem(
+          'Listening sockets',
+          `${formatCount(latestMetric.listeningTcp)} TCP • ${formatCount(latestMetric.listeningUdp)} UDP`
+        ),
+        buildSummaryItem('Unique domains', formatCount(latestMetric.uniqueDomains))
+      ],
+      items: buildDomainItems(latestMetric.domains)
+    },
+    throughput: {
+      id: 'throughput',
+      title: 'Network throughput',
+      headline: formatThroughputPair(latestMetric.netRx, latestMetric.netTx),
+      summary: [
+        buildSummaryItem('Inbound rate', formatThroughput(latestMetric.netRx)),
+        buildSummaryItem('Outbound rate', formatThroughput(latestMetric.netTx)),
+        buildSummaryItem(
+          'Average inbound (30s)',
+          formatThroughput(stats?.netRx?.avg)
+        ),
+        buildSummaryItem('Average outbound (30s)', formatThroughput(stats?.netTx?.avg))
+      ],
+      items: buildDomainItems(latestMetric.domains)
+    },
+    cpuAvg: {
+      id: 'cpuAvg',
+      title: 'CPU average (60s)',
+      headline: `${formatPercent(latestMetric.cpuAvg)}%`,
+      summary: [
+        buildSummaryItem('Rolling 60s average', `${formatPercent(latestMetric.cpuAvg)}%`),
+        buildSummaryItem('Session average', `${formatPercent(stats?.cpuAvg?.avg)}%`),
+        buildSummaryItem(
+          'Change since previous sample',
+          previousMetric ? `${formatPercent(latestMetric.cpuAvg - previousMetric.cpuAvg)}%` : '--'
+        )
+      ]
+    },
+    swap: {
+      id: 'swap',
+      title: 'Swap usage',
+      headline: `${formatPercent(latestMetric.swap)}%`,
+      summary: [
+        buildSummaryItem('Swap in use', `${formatPercent(latestMetric.swap)}%`),
+        buildSummaryItem('Memory pressure', `${formatPercent(latestMetric.memory)}%`),
+        buildSummaryItem('Processes', formatCount(latestMetric.processes))
+      ]
+    },
+    processes: {
+      id: 'processes',
+      title: 'Processes',
+      headline: formatCount(latestMetric.processes),
+      summary: [
+        buildSummaryItem('Running processes', formatCount(latestMetric.processes)),
+        buildSummaryItem('Threads observed', formatCount(latestMetric.threads)),
+        buildSummaryItem('CPU utilisation', `${formatPercent(latestMetric.cpu)}%`)
+      ],
+      items: buildApplicationItems(latestMetric.applications)
+    },
+    threads: {
+      id: 'threads',
+      title: 'Threads',
+      headline: formatCount(latestMetric.threads),
+      summary: [
+        buildSummaryItem('Total threads', formatCount(latestMetric.threads)),
+        buildSummaryItem('Processes', formatCount(latestMetric.processes)),
+        buildSummaryItem('CPU utilisation', `${formatPercent(latestMetric.cpu)}%`)
+      ],
+      items: buildApplicationItems(latestMetric.applications)
+    },
+    listeningSockets: {
+      id: 'listeningSockets',
+      title: 'Listening sockets',
+      headline: `${formatCount(latestMetric.listeningTcp)} TCP • ${formatCount(latestMetric.listeningUdp)} UDP`,
+      summary: [
+        buildSummaryItem('Listening TCP sockets', formatCount(latestMetric.listeningTcp)),
+        buildSummaryItem('Listening UDP sockets', formatCount(latestMetric.listeningUdp)),
+        buildSummaryItem('Active TCP connections', formatConnections(latestMetric.connections))
+      ],
+      description:
+        'Socket level telemetry is aggregated for privacy. Combine this with domain analytics to understand inbound and outbound listeners.'
+    },
+    uniqueDomains: {
+      id: 'uniqueDomains',
+      title: 'Unique domains',
+      headline: formatCount(latestMetric.uniqueDomains),
+      summary: [
+        buildSummaryItem('Unique domains observed', formatCount(latestMetric.uniqueDomains)),
+        buildSummaryItem('Total connections', formatConnections(latestMetric.connections)),
+        buildSummaryItem('Inbound rate', formatThroughput(latestMetric.netRx)),
+        buildSummaryItem('Outbound rate', formatThroughput(latestMetric.netTx))
+      ],
+      items: buildDomainItems(latestMetric.domains)
+    },
+    docker: {
+      id: 'docker',
+      title: 'Docker containers',
+      headline: formatCount(latestMetric?.dockerContainers?.length ?? 0),
+      summary: [
+        buildSummaryItem('Docker available', formatBoolean(latestMetric.dockerAvailable)),
+        buildSummaryItem('Running containers', formatCount(latestMetric?.dockerContainers?.length ?? 0)),
+        buildSummaryItem('Images discovered', formatCount(latestMetric?.dockerImages?.length ?? 0))
+      ],
+      items: [
+        ...buildDockerContainerItems(latestMetric?.dockerContainers ?? []),
+        ...buildDockerImageItems(latestMetric?.dockerImages ?? [])
+      ]
+    }
+  };
+
+  return detailMap;
+};
+


### PR DESCRIPTION
## Summary
- suppress docker CLI missing messages by redirecting command errors in the metrics collector
- reorganize the React dashboard into tabbed pages with a navigation bar
- add an interactive metric details panel with responsive styling and supporting utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5ef79d7a083338a89c1818f9caec6